### PR TITLE
Standardize all tap_action and hold_action

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -1,4 +1,5 @@
 import {
+    ActionConfig,
     fireEvent,
     HomeAssistant,
     LovelaceCardEditor,
@@ -13,6 +14,7 @@ import {
 import { ALARM_CONTROl_PANEL_CARD_EDITOR_NAME } from "./const";
 import { AlarmControlPanelCardConfig } from "./alarm-control-panel-card";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
+import { actionConfigStruct } from "../../utils/action-struct";
 
 const DOMAINS = ["group", "alarm_control_panel"];
 
@@ -22,8 +24,12 @@ const cardConfigStruct = assign(
         entity: string(),
         name: optional(string()),
         states: optional(array()),
+        tap_action: optional(actionConfigStruct),
+        hold_action: optional(actionConfigStruct),
     })
 );
+
+const actions = ["more-info", "navigate", "url", "call-service", "none"];
 
 /*
  * Ref: https://github.com/home-assistant/frontend/blob/dev/src/panels/lovelace/editor/config-elements/hui-alarm-panel-card-editor.ts
@@ -50,6 +56,14 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
 
     get _states(): string[] {
         return this._config!.states || [];
+    }
+
+    get _tap_action(): ActionConfig | undefined {
+        return this._config!.tap_action;
+    }
+
+    get _hold_action(): ActionConfig | undefined {
+        return this._config!.hold_action;
     }
 
     protected render(): TemplateResult {
@@ -123,6 +137,38 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
                             </paper-listbox>
                         </paper-dropdown-menu>
                     </div>
+                </div>
+                <div class="side-by-side">
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.tap_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._tap_action}
+                        .actions=${actions}
+                        .configValue=${"tap_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.hold_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._hold_action}
+                        .actions=${actions}
+                        .configValue=${"hold_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
                 </div>
             </div>
         `;

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -1,4 +1,5 @@
 import {
+    ActionConfig,
     computeRTLDirection,
     fireEvent,
     HomeAssistant,
@@ -8,6 +9,7 @@ import {
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert, assign, boolean, object, optional, string } from "superstruct";
+import { actionConfigStruct } from "../../utils/action-struct";
 import {
     baseLovelaceCardConfig,
     configElementStyle,
@@ -26,8 +28,19 @@ const cardConfigStruct = assign(
         name: optional(string()),
         show_buttons_control: optional(boolean()),
         show_position_control: optional(boolean()),
+        tap_action: optional(actionConfigStruct),
+        hold_action: optional(actionConfigStruct),
     })
 );
+
+const actions = [
+    "toggle",
+    "more-info",
+    "navigate",
+    "url",
+    "call-service",
+    "none",
+];
 
 @customElement(COVER_CARD_EDITOR_NAME)
 export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
@@ -58,6 +71,14 @@ export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
 
     get _showPositionControl(): boolean {
         return this._config!.show_position_control ?? false;
+    }
+
+    get _tap_action(): ActionConfig | undefined {
+        return this._config!.tap_action;
+    }
+
+    get _hold_action(): ActionConfig | undefined {
+        return this._config!.hold_action;
     }
 
     protected render(): TemplateResult {
@@ -119,6 +140,38 @@ export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
                             @change=${this._valueChanged}
                         ></ha-switch>
                     </ha-formfield>
+                </div>
+                <div class="side-by-side">
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.tap_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._tap_action}
+                        .actions=${actions}
+                        .configValue=${"tap_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.hold_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._hold_action}
+                        .actions=${actions}
+                        .configValue=${"hold_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
                 </div>
             </div>
         `;

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -1,4 +1,5 @@
 import {
+    ActionConfig,
     computeRTLDirection,
     fireEvent,
     HomeAssistant,
@@ -8,6 +9,7 @@ import {
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert, assign, boolean, object, optional, string } from "superstruct";
+import { actionConfigStruct } from "../../utils/action-struct";
 import {
     baseLovelaceCardConfig,
     configElementStyle,
@@ -26,8 +28,19 @@ const cardConfigStruct = assign(
         name: optional(string()),
         show_brightness_control: optional(boolean()),
         show_color_temp_control: optional(boolean()),
+        tap_action: optional(actionConfigStruct),
+        hold_action: optional(actionConfigStruct),
     })
 );
+
+const actions = [
+    "toggle",
+    "more-info",
+    "navigate",
+    "url",
+    "call-service",
+    "none",
+];
 
 @customElement(LIGHT_CARD_EDITOR_NAME)
 export class LightCardEditor extends LitElement implements LovelaceCardEditor {
@@ -58,6 +71,14 @@ export class LightCardEditor extends LitElement implements LovelaceCardEditor {
 
     get _showColorTempControl(): boolean {
         return this._config!.show_color_temp_control ?? false;
+    }
+
+    get _tap_action(): ActionConfig | undefined {
+        return this._config!.tap_action;
+    }
+
+    get _hold_action(): ActionConfig | undefined {
+        return this._config!.hold_action;
     }
 
     protected render(): TemplateResult {
@@ -119,6 +140,38 @@ export class LightCardEditor extends LitElement implements LovelaceCardEditor {
                             @change=${this._valueChanged}
                         ></ha-switch>
                     </ha-formfield>
+                </div>
+                <div class="side-by-side">
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.tap_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._tap_action}
+                        .actions=${actions}
+                        .configValue=${"tap_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.hold_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._hold_action}
+                        .actions=${actions}
+                        .configValue=${"hold_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
                 </div>
             </div>
         `;

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -1,4 +1,5 @@
 import {
+    ActionConfig,
     computeRTLDirection,
     fireEvent,
     HomeAssistant,
@@ -7,6 +8,7 @@ import {
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert, assign, boolean, object, optional, string } from "superstruct";
+import { actionConfigStruct } from "../../utils/action-struct";
 import {
     baseLovelaceCardConfig,
     configElementStyle,
@@ -26,8 +28,12 @@ const cardConfigStruct = assign(
         vertical: optional(boolean()),
         hide_state: optional(boolean()),
         use_entity_picture: optional(boolean()),
+        tap_action: optional(actionConfigStruct),
+        hold_action: optional(actionConfigStruct),
     })
 );
+
+const actions = ["more-info", "navigate", "url", "call-service", "none"];
 
 @customElement(PERSON_CARD_EDITOR_NAME)
 export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
@@ -62,6 +68,14 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
 
     get _use_entity_picture(): boolean {
         return !!this._config!.use_entity_picture;
+    }
+
+    get _tap_action(): ActionConfig | undefined {
+        return this._config!.tap_action;
+    }
+
+    get _hold_action(): ActionConfig | undefined {
+        return this._config!.hold_action;
     }
 
     protected render(): TemplateResult {
@@ -129,6 +143,38 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
                             @change=${this._valueChanged}
                         ></ha-switch>
                     </ha-formfield>
+                </div>
+                <div class="side-by-side">
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.tap_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._tap_action}
+                        .actions=${actions}
+                        .configValue=${"tap_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.hold_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._hold_action}
+                        .actions=${actions}
+                        .configValue=${"hold_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
                 </div>
             </div>
         `;

--- a/src/cards/switch-card/switch-card-editor.ts
+++ b/src/cards/switch-card/switch-card-editor.ts
@@ -1,4 +1,5 @@
 import {
+    ActionConfig,
     computeRTLDirection,
     fireEvent,
     HomeAssistant,
@@ -8,6 +9,7 @@ import {
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert, assign, boolean, object, optional, string } from "superstruct";
+import { actionConfigStruct } from "../../utils/action-struct";
 import {
     baseLovelaceCardConfig,
     configElementStyle,
@@ -26,8 +28,19 @@ const cardConfigStruct = assign(
         name: optional(string()),
         vertical: optional(boolean()),
         hide_state: optional(boolean()),
+        tap_action: optional(actionConfigStruct),
+        hold_action: optional(actionConfigStruct),
     })
 );
+
+const actions = [
+    "toggle",
+    "more-info",
+    "navigate",
+    "url",
+    "call-service",
+    "none",
+];
 
 @customElement(SWITCH_CARD_EDITOR_NAME)
 export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
@@ -58,6 +71,14 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
 
     get _hide_state(): boolean {
         return !!this._config!.hide_state;
+    }
+
+    get _tap_action(): ActionConfig | undefined {
+        return this._config!.tap_action;
+    }
+
+    get _hold_action(): ActionConfig | undefined {
+        return this._config!.hold_action;
     }
 
     protected render(): TemplateResult {
@@ -119,6 +140,38 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
                             @change=${this._valueChanged}
                         ></ha-switch>
                     </ha-formfield>
+                </div>
+                <div class="side-by-side">
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.tap_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._tap_action}
+                        .actions=${actions}
+                        .configValue=${"tap_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
+                    <hui-action-editor
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.hold_action"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .hass=${this.hass}
+                        .config=${this._hold_action}
+                        .actions=${actions}
+                        .configValue=${"hold_action"}
+                        .tooltipText=${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.button.default_action_help"
+                        )}
+                        @value-changed=${this._valueChanged}
+                    ></hui-action-editor>
                 </div>
             </div>
         `;


### PR DESCRIPTION
`tap_action` and `hold_action` are now unified : 
- default `tap_action` : Toggle entity if domain support it, otherwise open more-info dialog. 
- default `hold_action` : open more-info dialog.

| card | tap_action | hold_action |
|---|---|---|
| alarm_control_panel  | more-info | more-info |
| cover  | toggle | more-info |
| light | toggle | more-info |
| person | more-info | more-info |
| switch | toggle | more-info |

Actions are now editable from the GUI too.

Note: I saw that `double_tap_action` is also supported by action handler but I'm not sur we need it.