### PR TITLE
fix: don't display disarm button is no states selected

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -148,9 +148,12 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
                 mainEntity.state
             ) >= 0;
 
-        const actions: ActionButtonType[] = isDisarmed(mainEntity)
-            ? this._config.states?.map((state) => ({ state })) || []
-            : [{ state: "disarmed" }];
+        const actions: ActionButtonType[] =
+            this._config.states && this._config.states.length > 0
+                ? isDisarmed(mainEntity)
+                    ? this._config.states.map((state) => ({ state }))
+                    : [{ state: "disarmed" }]
+                : [];
 
         const isActionEnabled = isActionsAvailable(mainEntity);
 


### PR DESCRIPTION
We shouldn't have button when armed and disarmed when no states set.