### PR TITLE
Optional wrap secondary text in template card

### DIFF
--- a/docs/cards/template.md
+++ b/docs/cards/template.md
@@ -17,6 +17,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `icon_color`  | string          | Optional | Icon color to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                        |
 | `primary`     | string          | Optional | Primary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                      |
 | `secondary`   | string          | Optional | Secondary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                    |
+| `multiline_secondary`    | boolean         | `false`  | Enables support for multiline text for the secondary info.
 | `vertical`    | boolean         | `false`  | Vertical layout                                                                                                                     |
 | `hide_state`  | boolean         | `false`  | Hide the entity state                                                                                                               |
 | `tap_action`  | action          | `none`   | Home assistant action to perform on tap                                                                                             |

--- a/src/cards/template-card/template-card-config.ts
+++ b/src/cards/template-card/template-card-config.ts
@@ -16,7 +16,7 @@ export interface TemplateCardConfig extends LovelaceCardConfig {
     icon_color?: string;
     primary?: string;
     secondary?: string;
-    wrap_secondary?: boolean;
+    multiline_secondary?: boolean;
     vertical?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
@@ -30,7 +30,7 @@ export const templateCardConfigStruct = assign(
         icon_color: optional(string()),
         primary: optional(string()),
         secondary: optional(string()),
-        wrap_secondary: optional(boolean()),
+        multiline_secondary: optional(boolean()),
         vertical: optional(boolean()),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),

--- a/src/cards/template-card/template-card-config.ts
+++ b/src/cards/template-card/template-card-config.ts
@@ -16,6 +16,7 @@ export interface TemplateCardConfig extends LovelaceCardConfig {
     icon_color?: string;
     primary?: string;
     secondary?: string;
+    wrap_secondary?: boolean;
     vertical?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
@@ -29,6 +30,7 @@ export const templateCardConfigStruct = assign(
         icon_color: optional(string()),
         primary: optional(string()),
         secondary: optional(string()),
+        wrap_secondary: optional(boolean()),
         vertical: optional(boolean()),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -110,12 +110,12 @@ export class TemplateCardEditor
                         ></ha-switch>
                     </ha-formfield>
                     <ha-formfield
-                        .label=${customLocalize("editor.card.generic.wrap_text")}
+                        .label=${customLocalize("editor.card.generic.multiline_secondary")}
                         .dir=${dir}
                     >
                         <ha-switch
-                            .checked=${!!this._config.wrap_secondary}
-                            .configValue=${"wrap_secondary"}
+                            .checked=${!!this._config.multiline_secondary}
+                            .configValue=${"multiline_secondary"}
                             @change=${this._valueChanged}
                         ></ha-switch>
                     </ha-formfield>

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -109,6 +109,16 @@ export class TemplateCardEditor
                             @change=${this._valueChanged}
                         ></ha-switch>
                     </ha-formfield>
+                    <ha-formfield
+                        .label=${customLocalize("editor.card.generic.wrap_text")}
+                        .dir=${dir}
+                    >
+                        <ha-switch
+                            .checked=${!!this._config.wrap_secondary}
+                            .configValue=${"wrap_secondary"}
+                            @change=${this._valueChanged}
+                        ></ha-switch>
+                    </ha-formfield>
                 </div>
                 <div class="side-by-side">
                     <hui-action-editor

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -118,6 +118,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
         const secondary = this._templateResults.secondary?.result;
 
         const vertical = this._config.vertical;
+        const wrap_secondary = this._config.wrap_secondary;
 
         const iconStyle = {};
         if (iconColor) {
@@ -145,6 +146,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
                         slot="info"
                         .primary=${primary}
                         .secondary=${secondary}
+                        .wrap_secondary=${wrap_secondary}
                     ></mushroom-state-info>
                 </mushroom-state-item>
             </div>

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -118,7 +118,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
         const secondary = this._templateResults.secondary?.result;
 
         const vertical = this._config.vertical;
-        const wrap_secondary = this._config.wrap_secondary;
+        const multiline_secondary = this._config.multiline_secondary;
 
         const iconStyle = {};
         if (iconColor) {
@@ -146,7 +146,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
                         slot="info"
                         .primary=${primary}
                         .secondary=${secondary}
-                        .wrap_secondary=${wrap_secondary}
+                        .multiline_secondary=${multiline_secondary}
                     ></mushroom-state-info>
                 </mushroom-state-item>
             </div>

--- a/src/shared/state-info.ts
+++ b/src/shared/state-info.ts
@@ -7,14 +7,14 @@ export class StateItem extends LitElement {
 
     @property() public secondary?: string;
 
-    @property() public wrap_secondary?: boolean = false;
+    @property() public multiline_secondary?: boolean = false;
 
     protected render(): TemplateResult {
         return html`
             <div class="container">
                 <span class="primary">${this.primary}</span>
                 ${this.secondary
-                    ? html`<span class="secondary${this.wrap_secondary ? ` wrap`: ``}">${this.secondary}</span>`
+                    ? html`<span class="secondary${this.multiline_secondary ? ` multiline_secondary`: ``}">${this.secondary}</span>`
                     : null}
             </div>
         `;
@@ -44,7 +44,7 @@ export class StateItem extends LitElement {
                 overflow: hidden;
                 white-space: nowrap;
             }
-            .wrap {
+            .multiline_secondary {
                 white-space: normal;
             }
         `;

--- a/src/shared/state-info.ts
+++ b/src/shared/state-info.ts
@@ -7,12 +7,14 @@ export class StateItem extends LitElement {
 
     @property() public secondary?: string;
 
+    @property() public wrap_secondary?: boolean = false;
+
     protected render(): TemplateResult {
         return html`
             <div class="container">
                 <span class="primary">${this.primary}</span>
                 ${this.secondary
-                    ? html`<span class="secondary">${this.secondary}</span>`
+                    ? html`<span class="secondary${this.wrap_secondary ? ` wrap`: ``}">${this.secondary}</span>`
                     : null}
             </div>
         `;
@@ -41,6 +43,9 @@ export class StateItem extends LitElement {
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;
+            }
+            .wrap {
+                white-space: normal;
             }
         `;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3,7 +3,7 @@
         "card": {
             "generic": {
                 "vertical": "Vertical?",
-                "wrap_text": "Wrap text?",
+                "multiline_secondary": "Multiline secondary?",
                 "hide_state": "Hide state?",
                 "state": "State",
                 "icon_color": "Icon color",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -3,6 +3,7 @@
         "card": {
             "generic": {
                 "vertical": "Vertical?",
+                "wrap_text": "Wrap text?",
                 "hide_state": "Hide state?",
                 "state": "State",
                 "icon_color": "Icon color",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -3,6 +3,7 @@
         "card": {
             "generic": {
                 "vertical": "Vertical ?",
+                "wrap_text": "Envelopper le texte?",
                 "hide_state": "Cacher l'état ?",
                 "state": "État",
                 "icon_color": "Couleur de l'icône",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -3,7 +3,7 @@
         "card": {
             "generic": {
                 "vertical": "Vertical ?",
-                "wrap_text": "Envelopper le texte?",
+                "multiline_secondary": "Secondaire multiligne?",
                 "hide_state": "Cacher l'état ?",
                 "state": "État",
                 "icon_color": "Couleur de l'icône",


### PR DESCRIPTION
Adds the option to wrap text for the secondary row in the template card. 

Hope that PR's are welcome, though it is totally okay if you guys prefer not too! 😃

I am no frontend dev, nor TS developer, so please tell me if something can be done in a better.

I also don't speak French, so I used Google Translate for that one. 😄 

Fixes: #51 

![image](https://user-images.githubusercontent.com/67142049/152827683-ceb2c9f9-a353-4bf4-96f1-827b2bb6ef5b.png)
