### PR TITLE
Use relative time for entity card

### DIFF
--- a/src/cards/entity-card/utils.ts
+++ b/src/cards/entity-card/utils.ts
@@ -42,7 +42,7 @@ export function getInfo(
         case "name":
             return name;
         case "state":
-            if (entity.attributes.device_class === "timestamp") {
+            if (entity.attributes.device_class === "timestamp" && isAvailable(entity) == true) {
                 return html`
                 <ha-relative-time
                     .hass=${hass}

--- a/src/cards/entity-card/utils.ts
+++ b/src/cards/entity-card/utils.ts
@@ -42,7 +42,16 @@ export function getInfo(
         case "name":
             return name;
         case "state":
-            return state;
+            if (entity.attributes.device_class === "timestamp") {
+                return html`
+                <ha-relative-time
+                    .hass=${hass}
+                    .datetime=${entity.state}
+                    capitalize
+                ></ha-relative-time>`;
+            } else {
+                return state;
+            }
         case "last-changed":
             return html`
                 <ha-relative-time


### PR DESCRIPTION
Display timestamp as relative time. This is also the default behavior in Home Assistant. We can also make this configurable if wanted.