### PR TITLE
feat(icon): allow user to hide icon in template and entity cards

### DIFF
--- a/.hass_dev/views/entity-view.yaml
+++ b/.hass_dev/views/entity-view.yaml
@@ -10,6 +10,10 @@ cards:
         entity: sensor.power_consumption
         name: Custom name and icon
         icon: mdi:transmission-tower
+      - type: custom:mushroom-entity-card
+        entity: sensor.power_consumption
+        name: Hide icon
+        hide_icon: true
     columns: 2
     square: false
   - type: grid
@@ -63,7 +67,12 @@ cards:
         entity: sensor.power_consumption
         vertical: true
         secondary_info: none
-    columns: 2
+      - type: custom:mushroom-entity-card
+        entity: sensor.power_consumption
+        vertical: true
+        hide_icon: true
+        secondary_info: none
+    columns: 3
     square: false
   - type: grid
     title: Examples

--- a/.hass_dev/views/template-view.yaml
+++ b/.hass_dev/views/template-view.yaml
@@ -13,6 +13,11 @@ cards:
         secondary: |
           {{ states | count }} entities
         icon: mdi:format-list-bulleted
+      - type: custom:mushroom-template-card
+        primary: Hide icon
+        secondary: |
+          {{ states | count }} entities
+        hide_icon: true
     columns: 2
     square: false
   - type: grid
@@ -47,5 +52,11 @@ cards:
           {{ states | count }} entities
         icon: mdi:format-list-bulleted
         vertical: true
-    columns: 2
+      - type: custom:mushroom-template-card
+        primary: Hide icon
+        secondary: |
+          {{ states | count }} entities
+        hide_icon: true
+        vertical: true
+    columns: 3
     square: false

--- a/.hass_dev/views/template-view.yaml
+++ b/.hass_dev/views/template-view.yaml
@@ -17,7 +17,6 @@ cards:
         primary: Hide icon
         secondary: |
           {{ states | count }} entities
-        hide_icon: true
     columns: 2
     square: false
   - type: grid
@@ -56,7 +55,6 @@ cards:
         primary: Hide icon
         secondary: |
           {{ states | count }} entities
-        hide_icon: true
         vertical: true
     columns: 3
     square: false

--- a/docs/cards/entity.md
+++ b/docs/cards/entity.md
@@ -16,6 +16,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `entity`         | string                                              | Required    | Entity                                               |
 | `icon`           | string                                              | Optional    | Custom icon                                          |
 | `icon_color`     | string                                              | `blue`      | Custom color for icon when entity is state is active |
+| `hide_icon`      | boolean                                             | `false`     | Hide the entity icon                                 |
 | `name`           | string                                              | Optional    | Custom name                                          |
 | `vertical`       | boolean                                             | `false`     | Vertical layout                                      |
 | `primary_info`   | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                         |

--- a/docs/cards/template.md
+++ b/docs/cards/template.md
@@ -11,15 +11,16 @@ A template card allow you to build custom card.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name          | Type            | Default  | Description                                                                                                                         |
-| :------------ | :-------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------- |
-| `icon`        | string          | Optional | Icon to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                              |
-| `icon_color`  | string          | Optional | Icon color to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                        |
-| `primary`     | string          | Optional | Primary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                      |
-| `secondary`   | string          | Optional | Secondary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                    |
-| `multiline_secondary`    | boolean         | `false`  | Enables support for multiline text for the secondary info.
-| `vertical`    | boolean         | `false`  | Vertical layout                                                                                                                     |
-| `hide_state`  | boolean         | `false`  | Hide the entity state                                                                                                               |
-| `tap_action`  | action          | `none`   | Home assistant action to perform on tap                                                                                             |
-| `hold_action` | action          | `none`   | Home assistant action to perform on hold                                                                                            |
-| `entity_id`   | `string` `list` | Optional | Only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities. |
+| Name                  | Type            | Default  | Description                                                                                                                         |
+| :-------------------- | :-------------- | :------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+| `icon`                | string          | Optional | Icon to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                              |
+| `icon_color`          | string          | Optional | Icon color to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                        |
+| `hide_icon`           | boolean         | `false`  | Hide the icon                                                                                                                       |
+| `primary`             | string          | Optional | Primary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                      |
+| `secondary`           | string          | Optional | Secondary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                    |
+| `multiline_secondary` | boolean         | `false`  | Enables support for multiline text for the secondary info.                                                                          |
+| `vertical`            | boolean         | `false`  | Vertical layout                                                                                                                     |
+| `hide_state`          | boolean         | `false`  | Hide the entity state                                                                                                               |
+| `tap_action`          | action          | `none`   | Home assistant action to perform on tap                                                                                             |
+| `hold_action`         | action          | `none`   | Home assistant action to perform on hold                                                                                            |
+| `entity_id`           | `string` `list` | Optional | Only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities. |

--- a/src/cards/entity-card/entity-card-config.ts
+++ b/src/cards/entity-card/entity-card-config.ts
@@ -18,6 +18,7 @@ export interface EntityCardConfig extends LovelaceCardConfig {
     icon?: string;
     name?: string;
     icon_color?: string;
+    hide_icon?: boolean;
     vertical?: boolean;
     primary_info?: Info;
     secondary_info?: Info;
@@ -32,6 +33,7 @@ export const entityCardConfigStruct = assign(
         icon: optional(string()),
         name: optional(string()),
         icon_color: optional(string()),
+        hide_icon: optional(boolean()),
         vertical: optional(boolean()),
         primary_info: optional(enums(INFOS)),
         secondary_info: optional(enums(INFOS)),

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -119,6 +119,18 @@ export class EntityCardEditor extends LitElement implements LovelaceCardEditor {
                         </paper-listbox>
                     </paper-dropdown-menu>
                     <ha-formfield
+                        .label=${customLocalize("editor.card.generic.hide_icon")}
+                        .dir=${dir}
+                    >
+                        <ha-switch
+                            .checked=${!!this._config.hide_icon}
+                            .configValue=${"hide_icon"}
+                            @change=${this._valueChanged}
+                        ></ha-switch>
+                    </ha-formfield>
+                </div>
+                <div class="side-by-side">
+                    <ha-formfield
                         .label=${customLocalize("editor.card.generic.vertical")}
                         .dir=${dir}
                     >

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -83,7 +83,6 @@ export class EntityCard extends LitElement implements LovelaceCard {
         const name = this._config.name ?? entity.attributes.friendly_name ?? "";
         const icon = this._config.icon ?? stateIcon(entity);
         const hideIcon = !!this._config.hide_icon;
-        console.log(hideIcon);
         const vertical = this._config.vertical;
 
         const stateDisplay = computeStateDisplay(

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -123,13 +123,14 @@ export class EntityCard extends LitElement implements LovelaceCard {
                         hasHold: hasAction(this._config.hold_action),
                     })}
                     .hide_info=${primary == null && secondary == null}
+                    .hide_icon=${hideIcon}
                 >
                     ${!hideIcon ? html`<mushroom-shape-icon
                         slot="icon"
                         .disabled=${!isActive(entity)}
                         .icon=${icon}
                         style=${styleMap(iconStyle)}
-                    ></mushroom-shape-icon>` : null}
+                    ></mushroom-shape-icon>` : undefined}
                     ${!isAvailable(entity)
                         ? html`
                               <mushroom-badge-icon

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -82,6 +82,8 @@ export class EntityCard extends LitElement implements LovelaceCard {
 
         const name = this._config.name ?? entity.attributes.friendly_name ?? "";
         const icon = this._config.icon ?? stateIcon(entity);
+        const hideIcon = !!this._config.hide_icon;
+        console.log(hideIcon);
         const vertical = this._config.vertical;
 
         const stateDisplay = computeStateDisplay(
@@ -123,12 +125,12 @@ export class EntityCard extends LitElement implements LovelaceCard {
                     })}
                     .hide_info=${primary == null && secondary == null}
                 >
-                    <mushroom-shape-icon
+                    ${!hideIcon ? html`<mushroom-shape-icon
                         slot="icon"
                         .disabled=${!isActive(entity)}
                         .icon=${icon}
                         style=${styleMap(iconStyle)}
-                    ></mushroom-shape-icon>
+                    ></mushroom-shape-icon>` : null}
                     ${!isAvailable(entity)
                         ? html`
                               <mushroom-badge-icon

--- a/src/cards/template-card/template-card-config.ts
+++ b/src/cards/template-card/template-card-config.ts
@@ -14,6 +14,7 @@ import { baseLovelaceCardConfig } from "../../utils/editor-styles";
 export interface TemplateCardConfig extends LovelaceCardConfig {
     icon?: string;
     icon_color?: string;
+    hide_icon?: boolean;
     primary?: string;
     secondary?: string;
     multiline_secondary?: boolean;
@@ -28,6 +29,7 @@ export const templateCardConfigStruct = assign(
     object({
         icon: optional(string()),
         icon_color: optional(string()),
+        hide_icon: optional(boolean()),
         primary: optional(string()),
         secondary: optional(string()),
         multiline_secondary: optional(boolean()),

--- a/src/cards/template-card/template-card-config.ts
+++ b/src/cards/template-card/template-card-config.ts
@@ -14,7 +14,6 @@ import { baseLovelaceCardConfig } from "../../utils/editor-styles";
 export interface TemplateCardConfig extends LovelaceCardConfig {
     icon?: string;
     icon_color?: string;
-    hide_icon?: boolean;
     primary?: string;
     secondary?: string;
     multiline_secondary?: boolean;
@@ -29,7 +28,6 @@ export const templateCardConfigStruct = assign(
     object({
         icon: optional(string()),
         icon_color: optional(string()),
-        hide_icon: optional(boolean()),
         primary: optional(string()),
         secondary: optional(string()),
         multiline_secondary: optional(boolean()),

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -57,31 +57,21 @@ export class TemplateCardEditor
                         autocomplete="off"
                         spellcheck="false"
                     ></paper-textarea>
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.generic.hide_icon")}
-                        .dir=${dir}
-                    >
-                        <ha-switch
-                            .checked=${!!this._config.hide_icon}
-                            .configValue=${"hide_icon"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    <paper-textarea
+                        .label="${customLocalize(
+                            "editor.card.generic.icon_color"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .value=${this._config.icon_color}
+                        .configValue=${"icon_color"}
+                        @keydown=${this._ignoreKeydown}
+                        @value-changed=${this._valueChanged}
+                        autocapitalize="none"
+                        autocomplete="off"
+                        spellcheck="false"
+                    ></paper-textarea>
                 </div>
-                <paper-textarea
-                    .label="${customLocalize(
-                        "editor.card.generic.icon_color"
-                    )} (${this.hass.localize(
-                        "ui.panel.lovelace.editor.card.config.optional"
-                    )})"
-                    .value=${this._config.icon_color}
-                    .configValue=${"icon_color"}
-                    @keydown=${this._ignoreKeydown}
-                    @value-changed=${this._valueChanged}
-                    autocapitalize="none"
-                    autocomplete="off"
-                    spellcheck="false"
-                ></paper-textarea>
                 <paper-textarea
                     .label="${customLocalize(
                         "editor.card.template.primary"

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -42,20 +42,32 @@ export class TemplateCardEditor
 
         return html`
             <div class="card-config">
-                <paper-textarea
-                    .label="${this.hass.localize(
-                        "ui.panel.lovelace.editor.card.generic.icon"
-                    )} (${this.hass.localize(
-                        "ui.panel.lovelace.editor.card.config.optional"
-                    )})"
-                    .value=${this._config.icon}
-                    .configValue=${"icon"}
-                    @keydown=${this._ignoreKeydown}
-                    @value-changed=${this._valueChanged}
-                    autocapitalize="none"
-                    autocomplete="off"
-                    spellcheck="false"
-                ></paper-textarea>
+                <div class="side-by-side">
+                    <paper-textarea
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.icon"
+                        )} (${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.config.optional"
+                        )})"
+                        .value=${this._config.icon}
+                        .configValue=${"icon"}
+                        @keydown=${this._ignoreKeydown}
+                        @value-changed=${this._valueChanged}
+                        autocapitalize="none"
+                        autocomplete="off"
+                        spellcheck="false"
+                    ></paper-textarea>
+                    <ha-formfield
+                        .label=${customLocalize("editor.card.generic.hide_icon")}
+                        .dir=${dir}
+                    >
+                        <ha-switch
+                            .checked=${!!this._config.hide_icon}
+                            .configValue=${"hide_icon"}
+                            @change=${this._valueChanged}
+                        ></ha-switch>
+                    </ha-formfield>
+                </div>
                 <paper-textarea
                     .label="${customLocalize(
                         "editor.card.generic.icon_color"

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -114,7 +114,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
 
         const icon = this._templateResults.icon?.result;
         const iconColor = this._templateResults.icon_color?.result;
-        const hideIcon = !!this._config.hide_icon;
+        const hideIcon = !icon;
         const primary = this._templateResults.primary?.result;
         const secondary = this._templateResults.secondary?.result;
 

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -137,12 +137,13 @@ export class TemplateCard extends LitElement implements LovelaceCard {
                         hasHold: hasAction(this._config.hold_action),
                     })}
                     .hide_info=${!primary && !secondary}
+                    .hide_icon=${hideIcon}
                 >
                     ${!hideIcon ? html`<mushroom-shape-icon
                         style=${styleMap(iconStyle)}
                         slot="icon"
                         .icon=${icon}
-                    ></mushroom-shape-icon>` : null}
+                    ></mushroom-shape-icon>` : undefined}
                     <mushroom-state-info
                         slot="info"
                         .primary=${primary}

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -114,6 +114,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
 
         const icon = this._templateResults.icon?.result;
         const iconColor = this._templateResults.icon_color?.result;
+        const hideIcon = !!this._config.hide_icon;
         const primary = this._templateResults.primary?.result;
         const secondary = this._templateResults.secondary?.result;
 
@@ -137,11 +138,11 @@ export class TemplateCard extends LitElement implements LovelaceCard {
                     })}
                     .hide_info=${!primary && !secondary}
                 >
-                    <mushroom-shape-icon
+                    ${!hideIcon ? html`<mushroom-shape-icon
                         style=${styleMap(iconStyle)}
                         slot="icon"
                         .icon=${icon}
-                    ></mushroom-shape-icon>
+                    ></mushroom-shape-icon>` : null}
                     <mushroom-state-info
                         slot="info"
                         .primary=${primary}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -7,6 +7,7 @@
                 "hide_state": "Hide state?",
                 "state": "State",
                 "icon_color": "Icon color",
+                "hide_icon": "Hide icon?",
                 "color_values": {
                     "default": "Default color"
                 }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -7,6 +7,7 @@
                 "hide_state": "Cacher l'état ?",
                 "state": "État",
                 "icon_color": "Couleur de l'icône",
+                "hide_icon": "Cacher l'icône ?",
                 "color_values": {
                     "default": "Couleur par défaut"
                 }


### PR DESCRIPTION
<img width="984" alt="Capture d’écran 2022-02-08 à 01 39 18" src="https://user-images.githubusercontent.com/397503/152896061-fd22e4e1-9a17-487e-b0f4-21f5ce8b1f82.png">

Allow to hide icon on entity and template cards. In my opinion, not needed on every card.

Solves #47 