### PR TITLE
feat(person): use zone icon when available

### DIFF
--- a/.hass_dev/configuration.yaml
+++ b/.hass_dev/configuration.yaml
@@ -49,6 +49,13 @@ person:
     device_trackers:
       - device_tracker.demo_anne_therese
 
+zone:
+  - name: Office
+    latitude: 52.37451608362128
+    longitude: 4.888106097860146
+    radius: 50
+    icon: mdi:office-building
+
 vacuum:
   - platform: demo
 

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -95,7 +95,8 @@ export class PersonCard extends LitElement implements LovelaceCard {
         const vertical = !!this._config.vertical;
         const hideState = !!this._config.hide_state;
 
-        const stateIcon = getStateIcon(entity);
+        const zones = Object.values(this.hass.states).filter(entity => entity.entity_id.startsWith("zone."));
+        const stateIcon = getStateIcon(entity, zones);
         const stateColor = getStateColor(entity);
 
         const stateDisplay = computeStateDisplay(

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -7,7 +7,7 @@ export function getStateIcon(entity: HassEntity, zones:HassEntity[]) {
     } else if (state === "home") {
         return "mdi:home";
     }
-    const [zone] = zones.filter(z => state === z.attributes.friendly_name);
+    const zone = zones.find(z => state === z.attributes.friendly_name);
     if (zone) {
         return zone.attributes.icon;
     }

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -1,11 +1,15 @@
 import { HassEntity } from "home-assistant-js-websocket";
 
-export function getStateIcon(entity: HassEntity) {
+export function getStateIcon(entity: HassEntity, zones:HassEntity[]) {
     const state = entity.state;
     if (state === "unknown") {
         return "mdi:help";
     } else if (state === "home") {
         return "mdi:home";
+    }
+    const [zone] = zones.filter(z => state === z.attributes.friendly_name);
+    if (zone) {
+        return zone.attributes.icon;
     }
     return "mdi:home-export-outline";
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/397503/152899442-abb962c1-7ce1-476c-b7b2-756899d1a093.mp4

We didn't use zone icon, that's done. There is no cleaner thing than friendly name, the zone entity id is not in the person attributes.

Solves #53 