### PR TITLE
fix(chip): vertically center weather icon and make icon-only chips round

### DIFF
--- a/src/shared/chip.ts
+++ b/src/shared/chip.ts
@@ -24,12 +24,13 @@ export class BadgeIcon extends LitElement {
             .chip {
                 height: 36px;
                 width: auto;
-                padding: 0 12px;
+                padding: 0 10px;
                 border-radius: 18px;
                 display: flex;
                 flex-direction: row;
                 align-items: center;
                 justify-content: center;
+                line-height: 12px;
             }
             ::slotted(ha-icon) {
                 display: flex;


### PR DESCRIPTION
![chip fix](https://user-images.githubusercontent.com/397503/152904002-95e098c6-973f-4c18-829c-7b229389a3b5.png)

On iOS, weather icon is not vertically align. Other thing fixed, icon-only chips are now a real circle.