### PR TITLE
fix: show relative time for scenes

### DIFF
--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -18,7 +18,8 @@ export function getInfo(
         case "name":
             return name;
         case "state":
-            if (entity.attributes.device_class === "timestamp" && isAvailable(entity) == true) {
+            const domain = entity.entity_id.split(".")[0];
+            if ((entity.attributes.device_class === "timestamp" || domain === "scene") && isAvailable(entity) == true) {
                 return html` <ha-relative-time
                     .hass=${hass}
                     .datetime=${entity.state}


### PR DESCRIPTION
Scenes now have a state in Home Assistant since 2022.2. The state is a timestamp for when it was last activated. 

This makes it a human readable thing 😃 