### PR TITLE
add rgb and xy to light supported color modes

### DIFF
--- a/src/cards/light-card/utils.ts
+++ b/src/cards/light-card/utils.ts
@@ -32,5 +32,5 @@ export function supportsColorTempControl(entity: HassEntity): boolean {
 }
 
 export function supportsColorControl(entity: HassEntity): boolean {
-    return (entity.attributes.supported_color_modes ?? []).some((m) => ["hs", "rgbw", "rgbww"].includes(m));
+    return (entity.attributes.supported_color_modes ?? []).some((m) => ["hs", "rgb", "rgbw", "rgbww", "xy"].includes(m));
 }


### PR DESCRIPTION
Homeassistant [documentation](https://developers.home-assistant.io/docs/core/entity/light/#color-modes) says that supported color modes can be rgb,rgbw,rgbww,xy,hs.

In `supportsColorControl`, xy and rgb color modes were missing. 

Tested on my bulbs, which are xy, and everything seems to work fine.