### PR TITLE
fix(cover): disable pause button if not in motion

### DIFF
--- a/src/cards/cover-card/controls/cover-buttons-control.ts
+++ b/src/cards/cover-card/controls/cover-buttons-control.ts
@@ -39,7 +39,11 @@ export class CoverButtonsControl extends LitElement {
                 .disabled=${isFullyClosed(this.entity) || isClosing(this.entity)}
                 @click=${this._onCloseTap}
             ></mushroom-button>
-            <mushroom-button icon="mdi:pause" @click=${this._onStopTap}></mushroom-button>
+            <mushroom-button
+                icon="mdi:pause"
+                .disabled=${isFullyClosed(this.entity) || isFullyOpen(this.entity)}
+                @click=${this._onStopTap}
+            ></mushroom-button>
             <mushroom-button
                 icon="mdi:arrow-up"
                 .disabled=${isFullyOpen(this.entity) || isOpening(this.entity)}


### PR DESCRIPTION
A small UX/UI improvement given that you cannot pause while in a stopped state.

**Examples:**

In a closed state pause is disabled:

<img width="263" alt="image" src="https://user-images.githubusercontent.com/200190/153689252-0a6d455a-8365-441a-8a66-365d99dcaa53.png">

While opening pause is available:

<img width="254" alt="image" src="https://user-images.githubusercontent.com/200190/153689343-00616a12-458f-4273-acd5-57ba3bd4c8c7.png">

While closing pause is available:

<img width="266" alt="image" src="https://user-images.githubusercontent.com/200190/153689518-cb16710c-1ca7-491d-8e83-8095b662aa93.png">

In a opened state pause is disabled:

<img width="256" alt="image" src="https://user-images.githubusercontent.com/200190/153689352-ecca5af1-1b4d-474e-b1d8-12ce90ed3490.png">

