### PR TITLE
feat(layout): add default, horizontal and vertical layout for all cards

### DIFF
--- a/.hass_dev/views/alarm-control-panel-view.yaml
+++ b/.hass_dev/views/alarm-control-panel-view.yaml
@@ -22,27 +22,31 @@ cards:
       - armed_away
       - armed_night
     name: Template
-  - type: custom:mushroom-alarm-control-panel-card
-    entity: alarm_control_panel.alarm_panel_code
-    states:
-      - armed_home
-      - armed_away
-    name: Number code (1234)
-  - type: custom:mushroom-alarm-control-panel-card
-    entity: alarm_control_panel.alarm_panel_text_code
-    states:
-      - armed_home
-      - armed_away
-    name: Text code (azerty)
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-alarm-control-panel-card
+            entity: alarm_control_panel.alarm_panel_1
+            states:
+              - armed_home
+              - armed_away
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-alarm-control-panel-card
+            entity: alarm_control_panel.alarm_panel_1
+            states:
+              - armed_home
+              - armed_away
+            layout: "vertical"
       - type: custom:mushroom-alarm-control-panel-card
         entity: alarm_control_panel.alarm_panel_1
-        vertical: true
-      - type: custom:mushroom-alarm-control-panel-card
-        entity: alarm_control_panel.alarm_panel_1
-        vertical: true
-        hide_state: true
-    columns: 2
-    square: false
+        states:
+          - armed_home
+          - armed_away
+        layout: "horizontal"

--- a/.hass_dev/views/alarm-control-panel-view.yaml
+++ b/.hass_dev/views/alarm-control-panel-view.yaml
@@ -22,6 +22,18 @@ cards:
       - armed_away
       - armed_night
     name: Template
+  - type: custom:mushroom-alarm-control-panel-card
+    entity: alarm_control_panel.alarm_panel_code
+    states:
+      - armed_home
+      - armed_away
+    name: Number code (1234)
+  - type: custom:mushroom-alarm-control-panel-card
+    entity: alarm_control_panel.alarm_panel_text_code
+    states:
+      - armed_home
+      - armed_away
+    name: Text code (azerty)
   - type: vertical-stack
     title: Layout
     cards:

--- a/.hass_dev/views/cover-view.yaml
+++ b/.hass_dev/views/cover-view.yaml
@@ -30,15 +30,28 @@ cards:
     name: Multiple controls
     show_buttons_control: true
     show_position_control: true
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-cover-card
+            entity: cover.living_room_window
+            show_buttons_control: true
+            show_position_control: true
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-cover-card
+            entity: cover.living_room_window
+            show_buttons_control: true
+            show_position_control: true
+            layout: "vertical"
       - type: custom:mushroom-cover-card
         entity: cover.living_room_window
-        vertical: true
-      - type: custom:mushroom-cover-card
-        entity: cover.living_room_window
-        vertical: true
-        hide_state: true
-    columns: 2
-    square: false
+        show_buttons_control: true
+        show_position_control: true
+        layout: "horizontal"

--- a/.hass_dev/views/cover-view.yaml
+++ b/.hass_dev/views/cover-view.yaml
@@ -40,7 +40,6 @@ cards:
           - type: custom:mushroom-cover-card
             entity: cover.living_room_window
             show_buttons_control: true
-            show_position_control: true
       - type: grid
         columns: 2
         square: false
@@ -48,10 +47,8 @@ cards:
           - type: custom:mushroom-cover-card
             entity: cover.living_room_window
             show_buttons_control: true
-            show_position_control: true
             layout: "vertical"
       - type: custom:mushroom-cover-card
         entity: cover.living_room_window
         show_buttons_control: true
-        show_position_control: true
         layout: "horizontal"

--- a/.hass_dev/views/entity-view.yaml
+++ b/.hass_dev/views/entity-view.yaml
@@ -57,21 +57,25 @@ cards:
         icon_color: green
     columns: 2
     square: false
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-entity-card
+            entity: sensor.power_consumption
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-entity-card
+            entity: sensor.power_consumption
+            layout: "vertical"
       - type: custom:mushroom-entity-card
         entity: sensor.power_consumption
-        vertical: true
-      - type: custom:mushroom-entity-card
-        entity: sensor.power_consumption
-        vertical: true
-        secondary_info: none
-      - type: custom:mushroom-entity-card
-        entity: sensor.power_consumption
-        vertical: true
-        hide_icon: true
-        secondary_info: none
+        layout: "horizontal"
     columns: 3
     square: false
   - type: grid

--- a/.hass_dev/views/fan-view.yaml
+++ b/.hass_dev/views/fan-view.yaml
@@ -30,15 +30,28 @@ cards:
         show_oscillate_control: true
     columns: 2
     square: false
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-fan-card
+            entity: fan.living_room_fan
+            show_percentage_control: true
+            show_oscillate_control: true
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-fan-card
+            entity: fan.living_room_fan
+            show_percentage_control: true
+            show_oscillate_control: true
+            layout: "vertical"
       - type: custom:mushroom-fan-card
         entity: fan.living_room_fan
-        vertical: true
-      - type: custom:mushroom-fan-card
-        entity: fan.living_room_fan
-        vertical: true
-        hide_state: true
-    columns: 2
-    square: false
+        show_percentage_control: true
+        show_oscillate_control: true
+        layout: "horizontal"

--- a/.hass_dev/views/light-view.yaml
+++ b/.hass_dev/views/light-view.yaml
@@ -32,15 +32,25 @@ cards:
     show_color_temp_control: true
     show_color_control: true
     use_light_color: true
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-light-card
+            entity: light.bed_light
+            show_brightness_control: true
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-light-card
+            entity: light.bed_light
+            show_brightness_control: true
+            layout: "vertical"
       - type: custom:mushroom-light-card
         entity: light.bed_light
-        vertical: true
-      - type: custom:mushroom-light-card
-        entity: light.bed_light
-        vertical: true
-        hide_state: true
-    columns: 2
-    square: false
+        show_brightness_control: true
+        layout: "horizontal"

--- a/.hass_dev/views/person-view.yaml
+++ b/.hass_dev/views/person-view.yaml
@@ -16,24 +16,25 @@ cards:
         use_entity_picture: true
     columns: 2
     square: false
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-person-card
+            entity: person.anne_therese
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-person-card
+            entity: person.anne_therese
+            layout: "vertical"
       - type: custom:mushroom-person-card
         entity: person.anne_therese
-        vertical: true
-      - type: custom:mushroom-person-card
-        entity: person.anne_therese
-        vertical: true
-        hide_state: true
-      - type: custom:mushroom-person-card
-        entity: person.anne_therese
-        vertical: true
-        hide_state: true
-        use_entity_picture: true
-        hide_name: true
-    columns: 3
-    square: false
+        layout: "horizontal"
   - type: grid
     title: Demo controls
     cards:

--- a/.hass_dev/views/template-view.yaml
+++ b/.hass_dev/views/template-view.yaml
@@ -37,24 +37,30 @@ cards:
           {{ "green" if states | count > 50 else "red" }}  
     columns: 2
     square: false
-  - type: grid
-    title: Vertical
+  - type: vertical-stack
+    title: Layout
     cards:
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+        - type: custom:mushroom-template-card
+          primary: Hello, {{user}}
+          secondary: How are you?
+          icon: mdi:home
+      - type: grid
+        columns: 2
+        square: false
+        cards:
+          - type: custom:mushroom-template-card
+            primary: Hello, {{user}}
+            secondary: How are you?
+            hide_icon: true
+            icon: mdi:home
+            layout: "vertical"
       - type: custom:mushroom-template-card
         primary: Hello, {{user}}
         secondary: How are you?
+        hide_icon: true
         icon: mdi:home
-        vertical: true
-      - type: custom:mushroom-template-card
-        primary: Number of entities
-        secondary: |
-          {{ states | count }} entities
-        icon: mdi:format-list-bulleted
-        vertical: true
-      - type: custom:mushroom-template-card
-        primary: Hide icon
-        secondary: |
-          {{ states | count }} entities
-        vertical: true
-    columns: 3
-    square: false
+        layout: "horizontal"

--- a/docs/cards/alarm.md
+++ b/docs/cards/alarm.md
@@ -11,14 +11,14 @@ A alarm control panel card allow you to control a alarm panel entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                | Type    | Default                        | Description                                    |
-| :------------------ | :------ | :----------------------------- | :--------------------------------------------- |
-| `entity`            | string  | Required                       | Alarm control panel entity                     |
-| `icon`              | string  | Optional                       | Custom icon                                    |
-| `name`              | string  | Optional                       | Custom name                                    |
-| `vertical`          | boolean | `false`                        | Vertical layout                                |
-| `hide_state`        | boolean | `false`                        | Hide the entity state                          |
-| `states`            | list    | `["armed_home", "armed_away"]` | List of arm states to display                  |
-| `tap_action`        | action  | `more-info`                    | Home assistant action to perform on tap        |
-| `hold_action`       | action  | `more-info`                    | Home assistant action to perform on hold       |
-| `double_tap_action` | action  | `more-info`                    | Home assistant action to perform on double_tap |
+| Name                | Type    | Default                        | Description                                                               |
+| :------------------ | :------ | :----------------------------- | :------------------------------------------------------------------------ |
+| `entity`            | string  | Required                       | Alarm control panel entity                                                |
+| `icon`              | string  | Optional                       | Custom icon                                                               |
+| `name`              | string  | Optional                       | Custom name                                                               |
+| `layout`            | string  | Optional                       | Layout of the card. Vertical, horizontal and default layout are supported |
+| `hide_state`        | boolean | `false`                        | Hide the entity state                                                     |
+| `states`            | list    | `["armed_home", "armed_away"]` | List of arm states to display                                             |
+| `tap_action`        | action  | `more-info`                    | Home assistant action to perform on tap                                   |
+| `hold_action`       | action  | `more-info`                    | Home assistant action to perform on hold                                  |
+| `double_tap_action` | action  | `more-info`                    | Home assistant action to perform on double_tap                            |

--- a/docs/cards/cover.md
+++ b/docs/cards/cover.md
@@ -11,15 +11,15 @@ A cover card allow you to control a cover entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                    | Type    | Default     | Description                                    |
-| :---------------------- | :------ | :---------- | :--------------------------------------------- |
-| `entity`                | string  | Required    | Cover entity                                   |
-| `icon`                  | string  | Optional    | Custom icon                                    |
-| `name`                  | string  | Optional    | Custom name                                    |
-| `vertical`              | boolean | `false`     | Vertical layout                                |
-| `hide_state`            | boolean | `false`     | Hide the entity state                          |
-| `show_buttons_control`  | boolean | `false`     | Show buttons to open, close and stop cover     |
-| `show_position_control` | boolean | `false`     | Show a slider to control position of the cover |
-| `tap_action`            | action  | `toggle`    | Home assistant action to perform on tap        |
-| `hold_action`           | action  | `more-info` | Home assistant action to perform on hold       |
-| `double_tap_action`     | action  | `more-info` | Home assistant action to perform on double_tap |
+| Name                    | Type    | Default     | Description                                                               |
+| :---------------------- | :------ | :---------- | :------------------------------------------------------------------------ |
+| `entity`                | string  | Required    | Cover entity                                                              |
+| `icon`                  | string  | Optional    | Custom icon                                                               |
+| `name`                  | string  | Optional    | Custom name                                                               |
+| `layout`                | string  | Optional    | Layout of the card. Vertical, horizontal and default layout are supported |
+| `hide_state`            | boolean | `false`     | Hide the entity state                                                     |
+| `show_buttons_control`  | boolean | `false`     | Show buttons to open, close and stop cover                                |
+| `show_position_control` | boolean | `false`     | Show a slider to control position of the cover                            |
+| `tap_action`            | action  | `toggle`    | Home assistant action to perform on tap                                   |
+| `hold_action`           | action  | `more-info` | Home assistant action to perform on hold                                  |
+| `double_tap_action`     | action  | `more-info` | Home assistant action to perform on double_tap                            |

--- a/docs/cards/entity.md
+++ b/docs/cards/entity.md
@@ -11,16 +11,16 @@ A entity card allow you to display an entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                | Type                                                | Default     | Description                                          |
-| :------------------ | :-------------------------------------------------- | :---------- | :--------------------------------------------------- |
-| `entity`            | string                                              | Required    | Entity                                               |
-| `icon`              | string                                              | Optional    | Custom icon                                          |
-| `icon_color`        | string                                              | `blue`      | Custom color for icon when entity is state is active |
-| `hide_icon`         | boolean                                             | `false`     | Hide the entity icon                                 |
-| `name`              | string                                              | Optional    | Custom name                                          |
-| `vertical`          | boolean                                             | `false`     | Vertical layout                                      |
-| `primary_info`      | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                         |
-| `secondary_info`    | `name` `state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                       |
-| `tap_action`        | action                                              | `more-info` | Home assistant action to perform on tap              |
-| `hold_action`       | action                                              | `more-info` | Home assistant action to perform on hold             |
-| `double_tap_action` | action                                              | `more-info` | Home assistant action to perform on double_tap       |
+| Name                | Type                                                | Default     | Description                                                               |
+| :------------------ | :-------------------------------------------------- | :---------- | :------------------------------------------------------------------------ |
+| `entity`            | string                                              | Required    | Entity                                                                    |
+| `icon`              | string                                              | Optional    | Custom icon                                                               |
+| `icon_color`        | string                                              | `blue`      | Custom color for icon when entity is state is active                      |
+| `hide_icon`         | boolean                                             | `false`     | Hide the entity icon                                                      |
+| `name`              | string                                              | Optional    | Custom name                                                               |
+| `layout`            | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported |
+| `primary_info`      | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                              |
+| `secondary_info`    | `name` `state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                                            |
+| `tap_action`        | action                                              | `more-info` | Home assistant action to perform on tap                                   |
+| `hold_action`       | action                                              | `more-info` | Home assistant action to perform on hold                                  |
+| `double_tap_action` | action                                              | `more-info` | Home assistant action to perform on double_tap                            |

--- a/docs/cards/fan.md
+++ b/docs/cards/fan.md
@@ -11,16 +11,16 @@ A fan card allow you to control a fan entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                      | Type    | Default     | Description                                    |
-| :------------------------ | :------ | :---------- | :--------------------------------------------- |
-| `entity`                  | string  | Required    | Fan entity                                     |
-| `icon`                    | string  | Optional    | Custom icon                                    |
-| `name`                    | string  | Optional    | Custom name                                    |
-| `vertical`                | boolean | `false`     | Vertical layout                                |
-| `hide_state`              | boolean | `false`     | Hide the entity state                          |
-| `icon_animation`          | boolean | `false`     | Animate the icon when fan is `on`              |
-| `show_percentage_control` | boolean | `false`     | Show a slider to control speed                 |
-| `show_oscillate_control`  | boolean | `false`     | Show a button to control oscillation           |
-| `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap        |
-| `hold_action`             | action  | `more-info` | Home assistant action to perform on hold       |
-| `double_tap_action`       | action  | `more-info` | Home assistant action to perform on double_tap |
+| Name                      | Type    | Default     | Description                                                               |
+| :------------------------ | :------ | :---------- | :------------------------------------------------------------------------ |
+| `entity`                  | string  | Required    | Fan entity                                                                |
+| `icon`                    | string  | Optional    | Custom icon                                                               |
+| `name`                    | string  | Optional    | Custom name                                                               |
+| `layout`                  | string  | Optional    | Layout of the card. Vertical, horizontal and default layout are supported |
+| `hide_state`              | boolean | `false`     | Hide the entity state                                                     |
+| `icon_animation`          | boolean | `false`     | Animate the icon when fan is `on`                                         |
+| `show_percentage_control` | boolean | `false`     | Show a slider to control speed                                            |
+| `show_oscillate_control`  | boolean | `false`     | Show a button to control oscillation                                      |
+| `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                                   |
+| `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                                  |
+| `double_tap_action`       | action  | `more-info` | Home assistant action to perform on double_tap                            |

--- a/docs/cards/light.md
+++ b/docs/cards/light.md
@@ -11,17 +11,17 @@ A light card allow you to control a light entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                      | Type    | Default     | Description                                                       |
-| :------------------------ | :------ | :---------- | :---------------------------------------------------------------- |
-| `entity`                  | string  | Required    | Light entity                                                      |
-| `icon`                    | string  | Optional    | Custom icon                                                       |
-| `name`                    | string  | Optional    | Custom name                                                       |
-| `vertical`                | boolean | `false`     | Vertical layout                                                   |
-| `hide_state`              | boolean | `false`     | Hide the entity state                                             |
-| `show_brightness_control` | boolean | `false`     | Show a slider to control brightness                               |
-| `show_color_temp_control` | boolean | `false`     | Show a slider to control temperature color                        |
-| `show_color_control`      | boolean | `false`     | Show a slider to control RGB color                                |
-| `use_light_color`         | boolean | `false`     | Colorize the icon and slider according light temperature or color |
-| `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                           |
-| `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                          |
-| `double_tap_action`       | action  | `more-info` | Home assistant action to perform on double_tap                    |
+| Name                      | Type    | Default     | Description                                                               |
+| :------------------------ | :------ | :---------- | :------------------------------------------------------------------------ |
+| `entity`                  | string  | Required    | Light entity                                                              |
+| `icon`                    | string  | Optional    | Custom icon                                                               |
+| `name`                    | string  | Optional    | Custom name                                                               |
+| `layout`                  | string  | Optional    | Layout of the card. Vertical, horizontal and default layout are supported |
+| `hide_state`              | boolean | `false`     | Hide the entity state                                                     |
+| `show_brightness_control` | boolean | `false`     | Show a slider to control brightness                                       |
+| `show_color_temp_control` | boolean | `false`     | Show a slider to control temperature color                                |
+| `show_color_control`      | boolean | `false`     | Show a slider to control RGB color                                        |
+| `use_light_color`         | boolean | `false`     | Colorize the icon and slider according light temperature or color         |
+| `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                                   |
+| `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                                  |
+| `double_tap_action`       | action  | `more-info` | Home assistant action to perform on double_tap                            |

--- a/docs/cards/person.md
+++ b/docs/cards/person.md
@@ -11,15 +11,15 @@ A cover card allow you to control a person entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                 | Type    | Default     | Description                                          |
-| :------------------- | :------ | :---------- | :--------------------------------------------------- |
-| `entity`             | string  | Required    | Person entity                                        |
-| `icon`               | string  | Optional    | Custom icon                                          |
-| `name`               | string  | Optional    | Custom name                                          |
-| `vertical`           | boolean | `false`     | Vertical layout                                      |
-| `hide_state`         | boolean | `false`     | Hide the entity state                                |
-| `hide_name`          | boolean | `false`     | Hide the person name                                 |
-| `use_entity_picture` | boolean | `false`     | Use the picture of the person entity instead of icon |
-| `tap_action`         | action  | `more-info` | Home assistant action to perform on tap              |
-| `hold_action`        | action  | `more-info` | Home assistant action to perform on hold             |
-| `double_tap_action`  | action  | `more-info` | Home assistant action to perform on double_tap       |
+| Name                 | Type    | Default     | Description                                                               |
+| :------------------- | :------ | :---------- | :------------------------------------------------------------------------ |
+| `entity`             | string  | Required    | Person entity                                                             |
+| `icon`               | string  | Optional    | Custom icon                                                               |
+| `name`               | string  | Optional    | Custom name                                                               |
+| `layout`             | string  | Optional    | Layout of the card. Vertical, horizontal and default layout are supported |
+| `hide_state`         | boolean | `false`     | Hide the entity state                                                     |
+| `hide_name`          | boolean | `false`     | Hide the person name                                                      |
+| `use_entity_picture` | boolean | `false`     | Use the picture of the person entity instead of icon                      |
+| `tap_action`         | action  | `more-info` | Home assistant action to perform on tap                                   |
+| `hold_action`        | action  | `more-info` | Home assistant action to perform on hold                                  |
+| `double_tap_action`  | action  | `more-info` | Home assistant action to perform on double_tap                            |

--- a/docs/cards/template.md
+++ b/docs/cards/template.md
@@ -19,7 +19,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `primary`             | string          | Optional    | Primary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                      |
 | `secondary`           | string          | Optional    | Secondary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                    |
 | `multiline_secondary` | boolean         | `false`     | Enables support for multiline text for the secondary info.                                                                          |
-| `vertical`            | boolean         | `false`     | Vertical layout                                                                                                                     |
+| `layout`              | string          | Optional    | Layout of the card. Vertical, horizontal and default layout are supported                                                           |
 | `hide_state`          | boolean         | `false`     | Hide the entity state                                                                                                               |
 | `tap_action`          | action          | `none`      | Home assistant action to perform on tap                                                                                             |
 | `hold_action`         | action          | `none`      | Home assistant action to perform on hold                                                                                            |

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-config.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-config.ts
@@ -2,13 +2,14 @@ import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
 import { array, assign, boolean, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface AlarmControlPanelCardConfig extends LovelaceCardConfig {
     entity?: string;
     icon?: string;
     name?: string;
     states?: string[];
-    vertical?: boolean;
+    layout?: Layout;
     hide_state?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
@@ -22,7 +23,7 @@ export const alarmControlPanelCardCardConfigStruct = assign(
         name: optional(string()),
         icon: optional(string()),
         states: optional(array()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         hide_state: optional(boolean()),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -138,7 +138,7 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
                         >
                             <paper-listbox slot="dropdown-content">
                                 ${states.map(
-                                    (entityState) => html` <paper-item>${entityState}</paper-item>`
+                                    (entityState) => html`<paper-item>${entityState}</paper-item>`
                                 )}
                             </paper-listbox>
                         </paper-dropdown-menu>

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -166,7 +166,7 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
 
         return html`
             <ha-card>
-                <mushroom-card .layout=${layout} no-card-style="true">
+                <mushroom-card .layout=${layout} no-card-style>
                     <mushroom-state-item
                         .layout=${layout}
                         @action=${this._handleAction}
@@ -207,7 +207,7 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
                                   ${actions.map(
                                       (action) => html`
                                           <mushroom-button
-                                              icon=${getStateIcon(action.state)}
+                                              .icon=${getStateIcon(action.state)}
                                               @click=${(e) => this._onTap(e, action.state)}
                                               .disabled=${!isActionEnabled}
                                           ></mushroom-button>

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -184,11 +184,13 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
                             .icon=${icon}
                         ></mushroom-shape-icon>
                         ${entity.state === "unavailable"
-                            ? html` <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>`
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
                             : null}
                         <mushroom-state-info
                             slot="info"
@@ -235,7 +237,7 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
                           <div id="keypad">
                               ${BUTTONS.map((value) =>
                                   value === ""
-                                      ? html` <mwc-button disabled></mwc-button> `
+                                      ? html`<mwc-button disabled></mwc-button>`
                                       : html`
                                             <mwc-button
                                                 .value=${value}

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -269,6 +269,7 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
                 ha-card {
                     height: 100%;
                     box-sizing: border-box;
+                    padding: var(--spacing);
                 }
                 mushroom-state-item {
                     cursor: pointer;

--- a/src/cards/cover-card/controls/cover-buttons-control.ts
+++ b/src/cards/cover-card/controls/cover-buttons-control.ts
@@ -2,6 +2,7 @@ import { HomeAssistant } from "custom-card-helpers";
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
 import "../../../shared/button";
 import { isClosing, isFullyClosed, isFullyOpen, isOpening } from "../utils";
 
@@ -10,6 +11,8 @@ export class CoverButtonsControl extends LitElement {
     @property({ attribute: false }) public hass!: HomeAssistant;
 
     @property({ attribute: false }) public entity!: HassEntity;
+
+    @property() public fill: boolean = false;
 
     private _onOpenTap(e: MouseEvent): void {
         e.stopPropagation();
@@ -34,17 +37,24 @@ export class CoverButtonsControl extends LitElement {
 
     protected render(): TemplateResult {
         return html`
-            <mushroom-button
-                icon="mdi:arrow-down"
-                .disabled=${isFullyClosed(this.entity) || isClosing(this.entity)}
-                @click=${this._onCloseTap}
-            ></mushroom-button>
-            <mushroom-button icon="mdi:pause" @click=${this._onStopTap}></mushroom-button>
-            <mushroom-button
-                icon="mdi:arrow-up"
-                .disabled=${isFullyOpen(this.entity) || isOpening(this.entity)}
-                @click=${this._onOpenTap}
-            ></mushroom-button>
+            <div
+                class=${classMap({
+                    container: true,
+                    fill: this.fill,
+                })}
+            >
+                <mushroom-button
+                    icon="mdi:arrow-down"
+                    .disabled=${isFullyClosed(this.entity) || isClosing(this.entity)}
+                    @click=${this._onCloseTap}
+                ></mushroom-button>
+                <mushroom-button icon="mdi:pause" @click=${this._onStopTap}></mushroom-button>
+                <mushroom-button
+                    icon="mdi:arrow-up"
+                    .disabled=${isFullyOpen(this.entity) || isOpening(this.entity)}
+                    @click=${this._onOpenTap}
+                ></mushroom-button>
+            </div>
         `;
     }
 
@@ -58,7 +68,13 @@ export class CoverButtonsControl extends LitElement {
             :host *:not(:last-child) {
                 margin-right: var(--spacing);
             }
-            mushroom-button {
+            .container {
+                width: 100%;
+                display: flex;
+                flex-direction: row;
+                justify-content: flex-end;
+            }
+            .container.fill mushroom-button {
                 flex: 1;
             }
         `;

--- a/src/cards/cover-card/cover-card-config.ts
+++ b/src/cards/cover-card/cover-card-config.ts
@@ -2,12 +2,13 @@ import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
 import { assign, boolean, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface CoverCardConfig extends LovelaceCardConfig {
     entity?: string;
     icon?: string;
     name?: string;
-    vertical?: boolean;
+    layout?: Layout;
     hide_state?: boolean;
     show_buttons_control?: false;
     show_position_control?: false;
@@ -22,7 +23,7 @@ export const coverCardConfigStruct = assign(
         entity: optional(string()),
         icon: optional(string()),
         name: optional(string()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         hide_state: optional(boolean()),
         show_buttons_control: optional(boolean()),
         show_position_control: optional(boolean()),

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -9,6 +9,7 @@ import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { COVER_CARD_EDITOR_NAME, COVER_ENTITY_DOMAINS } from "./const";
@@ -91,16 +92,16 @@ export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
                     </ha-formfield>
                 </div>
                 <div class="side-by-side">
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.cover.show_buttons_control")}
-                        .dir=${dir}
+                    <mushroom-layout-picker
+                        .label="${customLocalize(
+                            "editor.card.generic.layout"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .hass=${this.hass}
+                        .value=${this._config.layout}
+                        .configValue=${"layout"}
+                        @value-changed=${this._valueChanged}
                     >
-                        <ha-switch
-                            .checked=${!!this._config.show_buttons_control}
-                            .configValue=${"show_buttons_control"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    </mushroom-layout-picker>
                     <ha-formfield
                         .label=${customLocalize("editor.card.cover.show_position_control")}
                         .dir=${dir}

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -21,7 +21,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive } from "../../utils/entity";
-import { getLayoutFromConfig } from "../../utils/layout";
+import { getLayoutFromConfig, Layout } from "../../utils/layout";
 import { COVER_CARD_EDITOR_NAME, COVER_CARD_NAME, COVER_ENTITY_DOMAINS } from "./const";
 import "./controls/cover-buttons-control";
 import "./controls/cover-position-control";
@@ -164,7 +164,8 @@ export class CoverCard extends LitElement implements LovelaceCard {
                 ${this._controls.length > 0
                     ? html`
                           <div class="actions">
-                              ${this.renderActiveControl(entity)} ${this.renderNextControlButton()}
+                              ${this.renderActiveControl(entity, layout)}
+                              ${this.renderNextControlButton()}
                           </div>
                       `
                     : null}
@@ -183,11 +184,15 @@ export class CoverCard extends LitElement implements LovelaceCard {
         `;
     }
 
-    private renderActiveControl(entity: HassEntity): TemplateResult | null {
+    private renderActiveControl(entity: HassEntity, layout?: Layout): TemplateResult | null {
         switch (this._activeControl) {
             case "buttons_control":
                 return html`
-                    <mushroom-cover-buttons-control .hass=${this.hass} .entity=${entity} />
+                    <mushroom-cover-buttons-control
+                        .hass=${this.hass}
+                        .entity=${entity}
+                        .fill=${layout !== "horizontal"}
+                    />
                 `;
             case "position_control":
                 return html`

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -13,6 +13,7 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../shared/badge-icon";
 import "../../shared/button";
+import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
@@ -20,6 +21,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive } from "../../utils/entity";
+import { getLayoutFromConfig } from "../../utils/layout";
 import { COVER_CARD_EDITOR_NAME, COVER_CARD_NAME, COVER_ENTITY_DOMAINS } from "./const";
 import "./controls/cover-buttons-control";
 import "./controls/cover-position-control";
@@ -119,7 +121,7 @@ export class CoverCard extends LitElement implements LovelaceCard {
 
         const name = this._config.name ?? entity.attributes.friendly_name;
         const icon = this._config.icon ?? stateIcon(entity);
-        const vertical = this._config.vertical;
+        const layout = getLayoutFromConfig(this._config);
         const hideState = this._config.hide_state;
 
         const stateDisplay = computeStateDisplay(this.hass.localize, entity, this.hass.locale);
@@ -132,44 +134,41 @@ export class CoverCard extends LitElement implements LovelaceCard {
         }
 
         return html`
-            <ha-card>
-                <div class="container">
-                    <mushroom-state-item
-                        .vertical=${vertical}
-                        @action=${this._handleAction}
-                        .actionHandler=${actionHandler({
-                            hasHold: hasAction(this._config.hold_action),
-                            hasDoubleClick: hasAction(this._config.double_tap_action),
-                        })}
-                    >
-                        <mushroom-shape-icon
-                            slot="icon"
-                            .disabled=${!isActive(entity)}
-                            .icon=${icon}
-                        ></mushroom-shape-icon>
-                        ${entity.state === "unavailable"
-                            ? html` <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>`
-                            : null}
-                        <mushroom-state-info
-                            slot="info"
-                            .primary=${name}
-                            .secondary=${!hideState && stateValue}
-                        ></mushroom-state-info>
-                    </mushroom-state-item>
-                    ${this._controls.length > 0
-                        ? html`
-                              <div class="actions">
-                                  ${this.renderActiveControl(entity)}
-                                  ${this.renderNextControlButton()}
-                              </div>
-                          `
+            <mushroom-card .layout=${layout}>
+                <mushroom-state-item
+                    .layout=${layout}
+                    @action=${this._handleAction}
+                    .actionHandler=${actionHandler({
+                        hasHold: hasAction(this._config.hold_action),
+                        hasDoubleClick: hasAction(this._config.double_tap_action),
+                    })}
+                >
+                    <mushroom-shape-icon
+                        slot="icon"
+                        .disabled=${!isActive(entity)}
+                        .icon=${icon}
+                    ></mushroom-shape-icon>
+                    ${entity.state === "unavailable"
+                        ? html` <mushroom-badge-icon
+                              class="unavailable"
+                              slot="badge"
+                              icon="mdi:help"
+                          ></mushroom-badge-icon>`
                         : null}
-                </div>
-            </ha-card>
+                    <mushroom-state-info
+                        slot="info"
+                        .primary=${name}
+                        .secondary=${!hideState && stateValue}
+                    ></mushroom-state-info>
+                </mushroom-state-item>
+                ${this._controls.length > 0
+                    ? html`
+                          <div class="actions">
+                              ${this.renderActiveControl(entity)} ${this.renderNextControlButton()}
+                          </div>
+                      `
+                    : null}
+            </mushroom-card>
         `;
     }
 

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -149,11 +149,13 @@ export class CoverCard extends LitElement implements LovelaceCard {
                         .icon=${icon}
                     ></mushroom-shape-icon>
                     ${entity.state === "unavailable"
-                        ? html` <mushroom-badge-icon
-                              class="unavailable"
-                              slot="badge"
-                              icon="mdi:help"
-                          ></mushroom-badge-icon>`
+                        ? html`
+                              <mushroom-badge-icon
+                                  class="unavailable"
+                                  slot="badge"
+                                  icon="mdi:help"
+                              ></mushroom-badge-icon>
+                          `
                         : null}
                     <mushroom-state-info
                         slot="info"

--- a/src/cards/entity-card/entity-card-config.ts
+++ b/src/cards/entity-card/entity-card-config.ts
@@ -3,6 +3,7 @@ import { assign, boolean, enums, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
 import { Info, INFOS } from "../../utils/info";
+import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface EntityCardConfig extends LovelaceCardConfig {
     entity?: string;
@@ -10,7 +11,7 @@ export interface EntityCardConfig extends LovelaceCardConfig {
     name?: string;
     icon_color?: string;
     hide_icon?: boolean;
-    vertical?: boolean;
+    layout?: Layout;
     primary_info?: Info;
     secondary_info?: Info;
     tap_action?: ActionConfig;
@@ -26,7 +27,7 @@ export const entityCardConfigStruct = assign(
         name: optional(string()),
         icon_color: optional(string()),
         hide_icon: optional(boolean()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         primary_info: optional(enums(INFOS)),
         secondary_info: optional(enums(INFOS)),
         tap_action: optional(actionConfigStruct),

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -11,6 +11,7 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/color-picker";
 import "../../shared/editor/info-picker";
+import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { ENTITY_CARD_EDITOR_NAME } from "./const";
@@ -92,16 +93,17 @@ export class EntityCardEditor extends LitElement implements LovelaceCardEditor {
                     </ha-formfield>
                 </div>
                 <div class="side-by-side">
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.generic.vertical")}
-                        .dir=${dir}
+                    <mushroom-layout-picker
+                        .label="${customLocalize(
+                            "editor.card.generic.layout"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .hass=${this.hass}
+                        .value=${this._config.layout}
+                        .configValue=${"layout"}
+                        @value-changed=${this._valueChanged}
                     >
-                        <ha-switch
-                            .checked=${!!this._config.vertical}
-                            .configValue=${"vertical"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    </mushroom-layout-picker>
+                    <span></span>
                 </div>
                 <div class="side-by-side">
                     <mushroom-info-picker

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -106,38 +106,34 @@ export class EntityCard extends LitElement implements LovelaceCard {
 
         const iconColor = this._config.icon_color;
 
-        return html`<mushroom-card .layout=${layout}>
-            <div class="container">
-                <mushroom-state-item
+        return html` <mushroom-card .layout=${layout}>
+            <mushroom-state-item
                 .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                    .hide_info=${primary == null && secondary == null}
-                    .hide_icon=${hideIcon}
-                >
-                    ${!hideIcon ? this.renderIcon(icon, iconColor, isActive(entity)) : undefined}
-                    ${
-                        !isAvailable(entity)
-                            ? html`
-                                  <mushroom-badge-icon
-                                      class="unavailable"
-                                      slot="badge"
-                                      icon="mdi:help"
-                                  ></mushroom-badge-icon>
-                              `
-                            : null
-                    }
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${primary}
-                        .secondary=${secondary}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-            </div>
-        </ha-card>`;
+                @action=${this._handleAction}
+                .actionHandler=${actionHandler({
+                    hasHold: hasAction(this._config.hold_action),
+                    hasDoubleClick: hasAction(this._config.double_tap_action),
+                })}
+                .hide_info=${primary == null && secondary == null}
+                .hide_icon=${hideIcon}
+            >
+                ${!hideIcon ? this.renderIcon(icon, iconColor, isActive(entity)) : undefined}
+                ${!isAvailable(entity)
+                    ? html`
+                          <mushroom-badge-icon
+                              class="unavailable"
+                              slot="badge"
+                              icon="mdi:help"
+                          ></mushroom-badge-icon>
+                      `
+                    : null}
+                <mushroom-state-info
+                    slot="info"
+                    .primary=${primary}
+                    .secondary=${secondary}
+                ></mushroom-state-info>
+            </mushroom-state-item>
+        </mushroom-card>`;
     }
 
     renderIcon(icon: string, iconColor: string | undefined, active: boolean): TemplateResult {

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -106,34 +106,36 @@ export class EntityCard extends LitElement implements LovelaceCard {
 
         const iconColor = this._config.icon_color;
 
-        return html` <mushroom-card .layout=${layout}>
-            <mushroom-state-item
-                .layout=${layout}
-                @action=${this._handleAction}
-                .actionHandler=${actionHandler({
-                    hasHold: hasAction(this._config.hold_action),
-                    hasDoubleClick: hasAction(this._config.double_tap_action),
-                })}
-                .hide_info=${primary == null && secondary == null}
-                .hide_icon=${hideIcon}
-            >
-                ${!hideIcon ? this.renderIcon(icon, iconColor, isActive(entity)) : undefined}
-                ${!isAvailable(entity)
-                    ? html`
-                          <mushroom-badge-icon
-                              class="unavailable"
-                              slot="badge"
-                              icon="mdi:help"
-                          ></mushroom-badge-icon>
-                      `
-                    : null}
-                <mushroom-state-info
-                    slot="info"
-                    .primary=${primary}
-                    .secondary=${secondary}
-                ></mushroom-state-info>
-            </mushroom-state-item>
-        </mushroom-card>`;
+        return html`
+            <mushroom-card .layout=${layout}>
+                <mushroom-state-item
+                    .layout=${layout}
+                    @action=${this._handleAction}
+                    .actionHandler=${actionHandler({
+                        hasHold: hasAction(this._config.hold_action),
+                        hasDoubleClick: hasAction(this._config.double_tap_action),
+                    })}
+                    .hide_info=${primary == null && secondary == null}
+                    .hide_icon=${hideIcon}
+                >
+                    ${!hideIcon ? this.renderIcon(icon, iconColor, isActive(entity)) : undefined}
+                    ${!isAvailable(entity)
+                        ? html`
+                              <mushroom-badge-icon
+                                  class="unavailable"
+                                  slot="badge"
+                                  icon="mdi:help"
+                              ></mushroom-badge-icon>
+                          `
+                        : null}
+                    <mushroom-state-info
+                        slot="info"
+                        .primary=${primary}
+                        .secondary=${secondary}
+                    ></mushroom-state-info>
+                </mushroom-state-item>
+            </mushroom-card>
+        `;
     }
 
     renderIcon(icon: string, iconColor: string | undefined, active: boolean): TemplateResult {

--- a/src/cards/fan-card/fan-card-config.ts
+++ b/src/cards/fan-card/fan-card-config.ts
@@ -2,12 +2,13 @@ import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
 import { assign, boolean, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface FanCardConfig extends LovelaceCardConfig {
     entity?: string;
     icon?: string;
     name?: string;
-    vertical?: boolean;
+    layout?: Layout;
     hide_state?: boolean;
     icon_animation?: boolean;
     show_percentage_control?: boolean;
@@ -24,7 +25,7 @@ export const fanCardConfigStruct = assign(
         name: optional(string()),
         icon: optional(string()),
         icon_animation: optional(boolean()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         hide_state: optional(boolean()),
         show_percentage_control: optional(boolean()),
         show_oscillate_control: optional(boolean()),

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -9,6 +9,7 @@ import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
@@ -81,16 +82,16 @@ export class FanCardEditor extends LitElement implements LovelaceCardEditor {
                     </ha-formfield>
                 </div>
                 <div class="side-by-side">
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.generic.vertical")}
-                        .dir=${dir}
+                    <mushroom-layout-picker
+                        .label="${customLocalize(
+                            "editor.card.generic.layout"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .hass=${this.hass}
+                        .value=${this._config.layout}
+                        .configValue=${"layout"}
+                        @value-changed=${this._valueChanged}
                     >
-                        <ha-switch
-                            .checked=${!!this._config.vertical}
-                            .configValue=${"vertical"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    </mushroom-layout-picker>
                     <ha-formfield
                         .label=${customLocalize("editor.card.generic.hide_state")}
                         .dir=${dir}

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -14,6 +14,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import "../../shared/badge-icon";
 import "../../shared/button";
+import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
@@ -21,6 +22,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive, isAvailable } from "../../utils/entity";
+import { getLayoutFromConfig } from "../../utils/layout";
 import { FAN_CARD_EDITOR_NAME, FAN_CARD_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import "./controls/fan-oscillate-control";
 import "./controls/fan-percentage-control";
@@ -86,7 +88,7 @@ export class FanCard extends LitElement implements LovelaceCard {
 
         const name = this._config.name ?? entity.attributes.friendly_name;
         const icon = this._config.icon ?? stateIcon(entity);
-        const vertical = this._config.vertical;
+        const layout = getLayoutFromConfig(this._config);
         const hideState = this._config.hide_state;
 
         const stateDisplay = computeStateDisplay(this.hass.localize, entity, this.hass.locale);
@@ -111,64 +113,62 @@ export class FanCard extends LitElement implements LovelaceCard {
         }
 
         return html`
-            <ha-card>
-                <div class="container">
-                    <mushroom-state-item
-                        .vertical=${vertical}
-                        @action=${this._handleAction}
-                        .actionHandler=${actionHandler({
-                            hasHold: hasAction(this._config.hold_action),
-                            hasDoubleClick: hasAction(this._config.double_tap_action),
+            <mushroom-card .layout=${layout}>
+                <mushroom-state-item
+                    .layout=${layout}
+                    @action=${this._handleAction}
+                    .actionHandler=${actionHandler({
+                        hasHold: hasAction(this._config.hold_action),
+                        hasDoubleClick: hasAction(this._config.double_tap_action),
+                    })}
+                >
+                    <mushroom-shape-icon
+                        slot="icon"
+                        class=${classMap({
+                            spin: active && !!this._config.icon_animation,
                         })}
-                    >
-                        <mushroom-shape-icon
-                            slot="icon"
-                            class=${classMap({
-                                spin: active && !!this._config.icon_animation,
-                            })}
-                            style=${styleMap(iconStyle)}
-                            .disabled=${!active}
-                            .icon=${icon}
-                        ></mushroom-shape-icon>
-                        ${!isAvailable(entity)
-                            ? html`
-                                  <mushroom-badge-icon
-                                      class="unavailable"
-                                      slot="badge"
-                                      icon="mdi:help"
-                                  ></mushroom-badge-icon>
-                              `
-                            : null}
-                        <mushroom-state-info
-                            slot="info"
-                            .primary=${name}
-                            .secondary=${!hideState && stateValue}
-                        ></mushroom-state-info>
-                    </mushroom-state-item>
-                    ${this._config.show_percentage_control || this._config.show_oscillate_control
+                        style=${styleMap(iconStyle)}
+                        .disabled=${!active}
+                        .icon=${icon}
+                    ></mushroom-shape-icon>
+                    ${!isAvailable(entity)
                         ? html`
-                              <div class="actions">
-                                  ${this._config.show_percentage_control
-                                      ? html`
-                                            <mushroom-fan-percentage-control
-                                                .hass=${this.hass}
-                                                .entity=${entity}
-                                            ></mushroom-fan-percentage-control>
-                                        `
-                                      : null}
-                                  ${this._config.show_oscillate_control
-                                      ? html`
-                                            <mushroom-fan-oscillate-control
-                                                .hass=${this.hass}
-                                                .entity=${entity}
-                                            ></mushroom-fan-oscillate-control>
-                                        `
-                                      : null}
-                              </div>
+                              <mushroom-badge-icon
+                                  class="unavailable"
+                                  slot="badge"
+                                  icon="mdi:help"
+                              ></mushroom-badge-icon>
                           `
                         : null}
-                </div>
-            </ha-card>
+                    <mushroom-state-info
+                        slot="info"
+                        .primary=${name}
+                        .secondary=${!hideState && stateValue}
+                    ></mushroom-state-info>
+                </mushroom-state-item>
+                ${this._config.show_percentage_control || this._config.show_oscillate_control
+                    ? html`
+                          <div class="actions">
+                              ${this._config.show_percentage_control
+                                  ? html`
+                                        <mushroom-fan-percentage-control
+                                            .hass=${this.hass}
+                                            .entity=${entity}
+                                        ></mushroom-fan-percentage-control>
+                                    `
+                                  : null}
+                              ${this._config.show_oscillate_control
+                                  ? html`
+                                        <mushroom-fan-oscillate-control
+                                            .hass=${this.hass}
+                                            .entity=${entity}
+                                        ></mushroom-fan-oscillate-control>
+                                    `
+                                  : null}
+                          </div>
+                      `
+                    : null}
+            </mushroom-card>
         `;
     }
 

--- a/src/cards/light-card/light-card-config.ts
+++ b/src/cards/light-card/light-card-config.ts
@@ -2,12 +2,13 @@ import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
 import { assign, boolean, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface LightCardConfig extends LovelaceCardConfig {
     entity?: string;
     icon?: string;
     name?: string;
-    vertical?: boolean;
+    layout?: Layout;
     hide_state?: boolean;
     show_brightness_control?: boolean;
     show_color_temp_control?: boolean;
@@ -24,7 +25,7 @@ export const lightCardConfigStruct = assign(
         entity: optional(string()),
         icon: optional(string()),
         name: optional(string()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         hide_state: optional(boolean()),
         show_brightness_control: optional(boolean()),
         show_color_temp_control: optional(boolean()),

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -9,6 +9,7 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
@@ -69,16 +70,16 @@ export class LightCardEditor extends LitElement implements LovelaceCardEditor {
                     ></ha-icon-picker>
                 </div>
                 <div class="side-by-side">
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.generic.vertical")}
-                        .dir=${dir}
+                    <mushroom-layout-picker
+                        .label="${customLocalize(
+                            "editor.card.generic.layout"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .hass=${this.hass}
+                        .value=${this._config.layout}
+                        .configValue=${"layout"}
+                        @value-changed=${this._valueChanged}
                     >
-                        <ha-switch
-                            .checked=${!!this._config.vertical}
-                            .configValue=${"vertical"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    </mushroom-layout-picker>
                     <ha-formfield
                         .label=${customLocalize("editor.card.generic.hide_state")}
                         .dir=${dir}

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -14,16 +14,19 @@ import { customElement, property, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import "../../shared/badge-icon";
 import "../../shared/button";
+import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
+import { isActive } from "../../utils/entity";
+import { getLayoutFromConfig } from "../../utils/layout";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_CARD_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
 import "./controls/light-brightness-control";
-import "./controls/light-color-temp-control";
 import "./controls/light-color-control";
+import "./controls/light-color-temp-control";
 import { LightCardConfig } from "./light-card-config";
 import "./light-card-editor";
 import {
@@ -31,10 +34,9 @@ import {
     getRGBColor,
     isLight,
     isSuperLight,
-    supportsColorTempControl,
     supportsColorControl,
+    supportsColorTempControl,
 } from "./utils";
-import { isActive } from "../../utils/entity";
 
 type LightCardControl = "brightness_control" | "color_temp_control" | "color_control";
 
@@ -145,7 +147,7 @@ export class LightCard extends LitElement implements LovelaceCard {
         const name = this._config.name ?? entity.attributes.friendly_name;
         const icon = this._config.icon ?? stateIcon(entity);
 
-        const vertical = !!this._config.vertical;
+        const layout = getLayoutFromConfig(this._config);
         const hideState = !!this._config.hide_state;
 
         const active = isActive(entity);
@@ -171,44 +173,44 @@ export class LightCard extends LitElement implements LovelaceCard {
         }
 
         return html`
-            <ha-card>
-                <div class="container">
-                    <mushroom-state-item
-                        .vertical=${vertical}
-                        @action=${this._handleAction}
-                        .actionHandler=${actionHandler({
-                            hasHold: hasAction(this._config.hold_action),
-                            hasDoubleClick: hasAction(this._config.double_tap_action),
-                        })}
-                    >
-                        <mushroom-shape-icon
-                            slot="icon"
-                            .disabled=${!active}
-                            .icon=${icon}
-                            style=${styleMap(iconStyle)}
-                        ></mushroom-shape-icon>
-                        ${entity.state === "unavailable"
-                            ? html` <mushroom-badge-icon
+            <mushroom-card .layout=${layout}>
+                <mushroom-state-item
+                    .layout=${layout}
+                    @action=${this._handleAction}
+                    .actionHandler=${actionHandler({
+                        hasHold: hasAction(this._config.hold_action),
+                        hasDoubleClick: hasAction(this._config.double_tap_action),
+                    })}
+                >
+                    <mushroom-shape-icon
+                        slot="icon"
+                        .disabled=${!active}
+                        .icon=${icon}
+                        style=${styleMap(iconStyle)}
+                    ></mushroom-shape-icon>
+                    ${entity.state === "unavailable"
+                        ? html`
+                              <mushroom-badge-icon
                                   class="unavailable"
                                   slot="badge"
                                   icon="mdi:help"
-                              ></mushroom-badge-icon>`
-                            : null}
-                        <mushroom-state-info
-                            slot="info"
-                            .primary=${name}
-                            .secondary=${!hideState && stateValue}
-                        ></mushroom-state-info>
-                    </mushroom-state-item>
-                    ${this._controls.length > 0
-                        ? html`
-                              <div class="actions">
-                                  ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
-                              </div>
+                              ></mushroom-badge-icon>
                           `
                         : null}
-                </div>
-            </ha-card>
+                    <mushroom-state-info
+                        slot="info"
+                        .primary=${name}
+                        .secondary=${!hideState && stateValue}
+                    ></mushroom-state-info>
+                </mushroom-state-item>
+                ${this._controls.length > 0
+                    ? html`
+                          <div class="actions">
+                              ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
+                          </div>
+                      `
+                    : null}
+            </mushroom-card>
         `;
     }
 

--- a/src/cards/person-card/person-card-config.ts
+++ b/src/cards/person-card/person-card-config.ts
@@ -2,16 +2,14 @@ import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
 import { assign, boolean, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { Layout, layoutStruct } from "../../utils/layout";
 
-/*
- * TODO: make configurable icons, icons according to zone, show state indicator
- */
 export interface PersonCardConfig extends LovelaceCardConfig {
     entity?: string;
     name?: string;
     icon?: string;
     use_entity_picture?: boolean;
-    vertical?: boolean;
+    layout?: Layout;
     hide_state?: boolean;
     hide_name?: boolean;
     tap_action?: ActionConfig;
@@ -26,7 +24,7 @@ export const personCardConfigStruct = assign(
         icon: optional(string()),
         name: optional(string()),
         use_entity_picture: optional(boolean()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         hide_state: optional(boolean()),
         hide_name: optional(boolean()),
         tap_action: optional(actionConfigStruct),

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -9,6 +9,7 @@ import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { PERSON_CARD_EDITOR_NAME, PERSON_ENTITY_DOMAINS } from "./const";
@@ -69,16 +70,16 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
                     ></ha-icon-picker>
                 </div>
                 <div class="side-by-side">
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.generic.vertical")}
-                        .dir=${dir}
+                    <mushroom-layout-picker
+                        .label="${customLocalize(
+                            "editor.card.generic.layout"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .hass=${this.hass}
+                        .value=${this._config.layout}
+                        .configValue=${"layout"}
+                        @value-changed=${this._valueChanged}
                     >
-                        <ha-switch
-                            .checked=${!!this._config.vertical}
-                            .configValue=${"vertical"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    </mushroom-layout-picker>
                     <ha-formfield
                         .label=${customLocalize("editor.card.person.use_entity_picture")}
                         .dir=${dir}

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -12,12 +12,14 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import "../../shared/badge-icon";
+import "../../shared/card";
 import "../../shared/shape-avatar";
 import "../../shared/shape-icon";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive } from "../../utils/entity";
+import { getLayoutFromConfig } from "../../utils/layout";
 import { PERSON_CARD_EDITOR_NAME, PERSON_CARD_NAME, PERSON_ENTITY_DOMAINS } from "./const";
 import { PersonCardConfig } from "./person-card-config";
 import "./person-card-editor";
@@ -86,7 +88,7 @@ export class PersonCard extends LitElement implements LovelaceCard {
             ? entity.attributes.entity_picture
             : undefined;
 
-        const vertical = !!this._config.vertical;
+        const layout = getLayoutFromConfig(this._config);
         const hideState = !!this._config.hide_state;
         const hideName = !!this._config.hide_name;
 
@@ -101,33 +103,37 @@ export class PersonCard extends LitElement implements LovelaceCard {
         const isAvailable = entity.state !== "unavailable";
 
         return html`
-            <ha-card>
+            <mushroom-card .layout=${layout}>
                 <div class="container">
                     <mushroom-state-item
-                        .vertical=${vertical}
+                        .layout=${layout}
                         @action=${this._handleAction}
                         .actionHandler=${actionHandler({
                             hasHold: hasAction(this._config.hold_action),
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture
-                            ? html`
-                                  <mushroom-shape-avatar
-                                      slot="icon"
-                                      .picture_url=${picture}
-                                  ></mushroom-shape-avatar>
-                              `
-                            : html`
-                                  <mushroom-shape-icon
-                                      slot="icon"
-                                      .icon=${icon}
-                                      .disabled=${!isActive(entity)}
-                                  ></mushroom-shape-icon>
-                              `}
-                        ${isAvailable
-                            ? this.renderStateBadge(stateIcon, stateColor)
-                            : this.renderUnvailableBadge()}
+                        ${
+                            picture
+                                ? html`
+                                      <mushroom-shape-avatar
+                                          slot="icon"
+                                          .picture_url=${picture}
+                                      ></mushroom-shape-avatar>
+                                  `
+                                : html`
+                                      <mushroom-shape-icon
+                                          slot="icon"
+                                          .icon=${icon}
+                                          .disabled=${!isActive(entity)}
+                                      ></mushroom-shape-icon>
+                                  `
+                        }
+                        ${
+                            isAvailable
+                                ? this.renderStateBadge(stateIcon, stateColor)
+                                : this.renderUnvailableBadge()
+                        }
                         <mushroom-state-info
                             slot="info"
                             .primary=${!hideName ? name : undefined}

--- a/src/cards/template-card/template-card-config.ts
+++ b/src/cards/template-card/template-card-config.ts
@@ -2,6 +2,7 @@ import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
 import { array, assign, boolean, object, optional, string, union } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface TemplateCardConfig extends LovelaceCardConfig {
     icon?: string;
@@ -9,7 +10,7 @@ export interface TemplateCardConfig extends LovelaceCardConfig {
     primary?: string;
     secondary?: string;
     multiline_secondary?: boolean;
-    vertical?: boolean;
+    layout?: Layout;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
     double_tap_action?: ActionConfig;
@@ -24,7 +25,7 @@ export const templateCardConfigStruct = assign(
         primary: optional(string()),
         secondary: optional(string()),
         multiline_secondary: optional(boolean()),
-        vertical: optional(boolean()),
+        layout: optional(layoutStruct),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),
         double_tap_action: optional(actionConfigStruct),

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -8,6 +8,7 @@ import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { TEMPLATE_CARD_EDITOR_NAME } from "./const";
@@ -87,16 +88,16 @@ export class TemplateCardEditor extends LitElement implements LovelaceCardEditor
                     spellcheck="false"
                 ></paper-textarea>
                 <div class="side-by-side">
-                    <ha-formfield
-                        .label=${customLocalize("editor.card.generic.vertical")}
-                        .dir=${dir}
+                    <mushroom-layout-picker
+                        .label="${customLocalize(
+                            "editor.card.generic.layout"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .hass=${this.hass}
+                        .value=${this._config.layout}
+                        .configValue=${"layout"}
+                        @value-changed=${this._valueChanged}
                     >
-                        <ha-switch
-                            .checked=${!!this._config.vertical}
-                            .configValue=${"vertical"}
-                            @change=${this._valueChanged}
-                        ></ha-switch>
-                    </ha-formfield>
+                    </mushroom-layout-picker>
                     <ha-formfield
                         .label=${customLocalize("editor.card.generic.multiline_secondary")}
                         .dir=${dir}

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -17,6 +17,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
+import { getLayoutFromConfig } from "../../utils/layout";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../../utils/ws-templates";
 import { TEMPLATE_CARD_EDITOR_NAME, TEMPLATE_CARD_NAME } from "./const";
 import { TemplateCardConfig } from "./template-card-config";
@@ -114,7 +115,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
 
         const hideIcon = !icon;
 
-        const vertical = this._config.vertical;
+        const layout = getLayoutFromConfig(this._config);
         const multiline_secondary = this._config.multiline_secondary;
 
         const iconStyle = {};
@@ -125,28 +126,26 @@ export class TemplateCard extends LitElement implements LovelaceCard {
         }
 
         return html`
-            <ha-card>
-                <div class="container">
-                    <mushroom-state-item
-                        .vertical=${vertical}
-                        @action=${this._handleAction}
-                        .actionHandler=${actionHandler({
-                            hasHold: hasAction(this._config.hold_action),
-                            hasDoubleClick: hasAction(this._config.double_tap_action),
-                        })}
-                        .hide_info=${!primary && !secondary}
-                        .hide_icon=${hideIcon}
-                    >
-                        ${!hideIcon ? this.renderIcon(icon, iconColor) : undefined}
-                        <mushroom-state-info
-                            slot="info"
-                            .primary=${primary}
-                            .secondary=${secondary}
-                            .multiline_secondary=${multiline_secondary}
-                        ></mushroom-state-info>
-                    </mushroom-state-item>
-                </div>
-            </ha-card>
+            <mushroom-card .layout=${layout}>
+                <mushroom-state-item
+                    .layout=${layout}
+                    @action=${this._handleAction}
+                    .actionHandler=${actionHandler({
+                        hasHold: hasAction(this._config.hold_action),
+                        hasDoubleClick: hasAction(this._config.double_tap_action),
+                    })}
+                    .hide_info=${!primary && !secondary}
+                    .hide_icon=${hideIcon}
+                >
+                    ${!hideIcon ? this.renderIcon(icon, iconColor) : undefined}
+                    <mushroom-state-info
+                        slot="info"
+                        .primary=${primary}
+                        .secondary=${secondary}
+                        .multiline_secondary=${multiline_secondary}
+                    ></mushroom-state-info>
+                </mushroom-state-item>
+            </mushroom-card>
         `;
     }
 

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -7,7 +7,7 @@ import { Layout } from "../utils/layout";
 export class Card extends LitElement {
     @property({ attribute: "no-card-style" }) public noCardStyle?: boolean;
 
-    @property() public layout?: Layout;
+    @property() public layout: Layout = "default";
 
     protected render(): TemplateResult {
         console.log(this.noCardStyle);

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -35,6 +35,7 @@ export class Card extends LitElement {
                 height: 100%;
                 box-sizing: border-box;
                 padding: var(--spacing);
+                justify-content: center;
             }
             .container > ::slotted(*:not(:last-child)) {
                 margin-bottom: var(--spacing);

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -1,0 +1,54 @@
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { property, customElement } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { Layout } from "../utils/layout";
+
+@customElement("mushroom-card")
+export class Card extends LitElement {
+    @property() public layout?: Layout;
+
+    protected render(): TemplateResult {
+        return html`
+            <ha-card>
+                <div
+                    class=${classMap({
+                        container: true,
+                        horizontal: this.layout === "horizontal",
+                    })}
+                >
+                    <slot></slot>
+                </div>
+            </ha-card>
+        `;
+    }
+
+    static get styles(): CSSResultGroup {
+        return css`
+            ha-card {
+                height: 100%;
+                box-sizing: border-box;
+            }
+            .container {
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                height: 100%;
+                box-sizing: border-box;
+                padding: var(--spacing);
+            }
+            .container > ::slotted(*:not(:last-child)) {
+                margin-bottom: var(--spacing);
+            }
+            .container.horizontal {
+                flex-direction: row;
+            }
+            .container.horizontal > ::slotted(*) {
+                flex: 1;
+            }
+            .container.horizontal > ::slotted(*:not(:last-child)) {
+                margin-right: var(--spacing);
+                margin-bottom: 0;
+            }
+        `;
+    }
+}

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -5,7 +5,7 @@ import { Layout } from "../utils/layout";
 
 @customElement("mushroom-card")
 export class Card extends LitElement {
-    @property({ attribute: "no-card-style" }) public noCardStyle?: boolean;
+    @property({ attribute: "no-card-style", type: Boolean }) public noCardStyle?: boolean;
 
     @property() public layout: Layout = "default";
 
@@ -34,6 +34,7 @@ export class Card extends LitElement {
             ha-card {
                 height: 100%;
                 box-sizing: border-box;
+                padding: var(--spacing);
             }
             .container {
                 display: flex;
@@ -41,7 +42,6 @@ export class Card extends LitElement {
                 width: 100%;
                 height: 100%;
                 box-sizing: border-box;
-                padding: var(--spacing);
                 justify-content: center;
             }
             .container > ::slotted(*:not(:last-child)) {

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -10,11 +10,10 @@ export class Card extends LitElement {
     @property() public layout: Layout = "default";
 
     protected render(): TemplateResult {
-        console.log(this.noCardStyle);
         if (this.noCardStyle) {
             return this.renderContent();
         }
-        return html`<ha-card> ${this.renderContent()} </ha-card>`;
+        return html`<ha-card>${this.renderContent()}</ha-card>`;
     }
 
     renderContent() {

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -5,20 +5,28 @@ import { Layout } from "../utils/layout";
 
 @customElement("mushroom-card")
 export class Card extends LitElement {
+    @property({ attribute: "no-card-style" }) public noCardStyle?: boolean;
+
     @property() public layout?: Layout;
 
     protected render(): TemplateResult {
+        console.log(this.noCardStyle);
+        if (this.noCardStyle) {
+            return this.renderContent();
+        }
+        return html`<ha-card> ${this.renderContent()} </ha-card>`;
+    }
+
+    renderContent() {
         return html`
-            <ha-card>
-                <div
-                    class=${classMap({
-                        container: true,
-                        horizontal: this.layout === "horizontal",
-                    })}
-                >
-                    <slot></slot>
-                </div>
-            </ha-card>
+            <div
+                class=${classMap({
+                    container: true,
+                    horizontal: this.layout === "horizontal",
+                })}
+            >
+                <slot></slot>
+            </div>
         `;
     }
 

--- a/src/shared/chip.ts
+++ b/src/shared/chip.ts
@@ -23,6 +23,7 @@ export class BadgeIcon extends LitElement {
                 --text-color: var(--primary-text-color);
             }
             .chip {
+                box-sizing: border-box;
                 height: var(--chip-height);
                 font-size: calc(var(--chip-height) * 0.3);
                 width: auto;

--- a/src/shared/editor/layout-picker.ts
+++ b/src/shared/editor/layout-picker.ts
@@ -1,0 +1,60 @@
+import { HomeAssistant } from "custom-card-helpers";
+import { css, CSSResultGroup, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import setupCustomlocalize from "../../localize";
+
+@customElement("mushroom-layout-picker")
+export class LayoutPicker extends LitElement {
+    @property() public label = "";
+
+    @property() public value?: string;
+
+    @property() public configValue = "";
+
+    @property() public hass!: HomeAssistant;
+
+    _selectChanged(ev: CustomEvent) {
+        const value = ev.detail.item.value;
+        this.dispatchEvent(
+            new CustomEvent("value-changed", {
+                detail: {
+                    value,
+                },
+            })
+        );
+    }
+
+    render() {
+        const customLocalize = setupCustomlocalize(this.hass);
+
+        return html`
+            <paper-dropdown-menu .label=${this.label}>
+                <paper-listbox
+                    slot="dropdown-content"
+                    attr-for-selected="value"
+                    .selected=${this.value ?? ""}
+                    .configValue=${this.configValue}
+                    @iron-select=${this._selectChanged}
+                >
+                    <paper-item value="">
+                        ${customLocalize("editor.form.layout_picker.values.default")}
+                    </paper-item>
+                    <paper-item .value=${"vertical"}>
+                        ${customLocalize("editor.form.layout_picker.values.vertical")}
+                    </paper-item>
+                    <paper-item .value=${"horizontal"}>
+                        ${customLocalize("editor.form.layout_picker.values.horizontal")}
+                    </paper-item>
+                </paper-listbox>
+            </paper-dropdown-menu>
+        `;
+    }
+
+    static get styles(): CSSResultGroup {
+        return css`
+            paper-dropdown-menu {
+                width: 100%;
+            }
+        `;
+    }
+}

--- a/src/shared/state-item.ts
+++ b/src/shared/state-item.ts
@@ -1,11 +1,12 @@
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { property, customElement } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
+import { Layout } from "../utils/layout";
 import "./shape-icon";
 
 @customElement("mushroom-state-item")
 export class StateItem extends LitElement {
-    @property() public vertical: boolean = false;
+    @property() public layout?: Layout;
 
     @property() public hide_icon: boolean = false;
 
@@ -16,19 +17,23 @@ export class StateItem extends LitElement {
             <div
                 class=${classMap({
                     container: true,
-                    vertical: this.vertical,
+                    vertical: this.layout === "vertical",
                 })}
             >
                 ${!this.hide_icon
-                    ? html`<div class="icon">
-                          <slot name="icon"></slot>
-                          <slot name="badge"></slot>
-                      </div>`
+                    ? html`
+                          <div class="icon">
+                              <slot name="icon"></slot>
+                              <slot name="badge"></slot>
+                          </div>
+                      `
                     : null}
                 ${!this.hide_info
-                    ? html`<div class="info">
-                          <slot name="info" class="info"></slot>
-                      </div>`
+                    ? html`
+                          <div class="info">
+                              <slot name="info"></slot>
+                          </div>
+                      `
                     : null}
             </div>
         `;

--- a/src/shared/state-item.ts
+++ b/src/shared/state-item.ts
@@ -6,7 +6,7 @@ import "./shape-icon";
 
 @customElement("mushroom-state-item")
 export class StateItem extends LitElement {
-    @property() public layout?: Layout;
+    @property() public layout: Layout = "default";
 
     @property() public hide_icon: boolean = false;
 

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -15,16 +15,23 @@
                     "last-updated": "Last Updated",
                     "none": "None"
                 }
+            },
+            "layout_picker": {
+                "values": {
+                    "default": "Default layout",
+                    "vertical": "Vertical layout",
+                    "horizontal": "Horizontal layout"
+                }
             }
         },
         "card": {
             "generic": {
-                "vertical": "Vertical?",
                 "multiline_secondary": "Multiline secondary?",
                 "hide_state": "Hide state?",
                 "state": "State",
                 "icon_color": "Icon color",
-                "hide_icon": "Hide icon?"
+                "hide_icon": "Hide icon?",
+                "layout": "Layout"
             },
             "light": {
                 "show_brightness_control": "Brightness control?",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -15,16 +15,23 @@
                     "last-updated": "Dernière mise à jour",
                     "none": "Aucune"
                 }
+            },
+            "layout_picker": {
+                "values": {
+                    "default": "Disposition par défault",
+                    "vertical": "Disposition verticale",
+                    "horizontal": "Disposition horizontale"
+                }
             }
         },
         "card": {
             "generic": {
-                "vertical": "Vertical ?",
                 "multiline_secondary": "Information secondaire sur plusieurs lignes?",
                 "hide_state": "Cacher l'état ?",
                 "state": "État",
                 "icon_color": "Couleur de l'icône",
-                "hide_icon": "Cacher l'icône ?"
+                "hide_icon": "Cacher l'icône ?",
+                "layout": "Disposition"
             },
             "light": {
                 "show_brightness_control": "Contrôle de luminosité ?",

--- a/src/utils/card-styles.ts
+++ b/src/utils/card-styles.ts
@@ -27,6 +27,7 @@ export const cardStyle = css`
         display: flex;
         flex-direction: row;
         align-items: flex-start;
+        justify-content: flex-end;
         overflow-y: auto;
     }
     .actions *:not(:last-child) {

--- a/src/utils/card-styles.ts
+++ b/src/utils/card-styles.ts
@@ -23,21 +23,6 @@ export const cardStyle = css`
         --chip-height: var(--mush-chip-height, 36px);
         --chip-border-radius: var(--mush-chip-border-radius, 18px);
     }
-    ha-card {
-        height: 100%;
-        box-sizing: border-box;
-    }
-    .container {
-        height: 100%;
-        box-sizing: border-box;
-        justify-content: center;
-        display: flex;
-        flex-direction: column;
-        padding: var(--spacing);
-    }
-    .container > *:not(:last-child) {
-        margin-bottom: var(--spacing);
-    }
     .actions {
         display: flex;
         flex-direction: row;

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -23,11 +23,13 @@ export function getInfo(
                 (entity.attributes.device_class === "timestamp" || domain === "scene") &&
                 isAvailable(entity) == true
             ) {
-                return html` <ha-relative-time
-                    .hass=${hass}
-                    .datetime=${entity.state}
-                    capitalize
-                ></ha-relative-time>`;
+                return html`
+                    <ha-relative-time
+                        .hass=${hass}
+                        .datetime=${entity.state}
+                        capitalize
+                    ></ha-relative-time>
+                `;
             } else {
                 return state;
             }

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,0 +1,5 @@
+import { literal, union } from "superstruct";
+
+export type Layout = "vertical" | "horizontal";
+
+export const layoutStruct = union([literal("horizontal"), literal("vertical")]);

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -1,14 +1,14 @@
 import { literal, union } from "superstruct";
 
-export type Layout = "vertical" | "horizontal";
+export type Layout = "vertical" | "horizontal" | "default";
 
-export const layoutStruct = union([literal("horizontal"), literal("vertical")]);
+export const layoutStruct = union([literal("horizontal"), literal("vertical"), literal("default")]);
 
 type ConfigWithLayout = {
     layout?: Layout;
     [key: string]: any;
 };
-export function getLayoutFromConfig(config: ConfigWithLayout): Layout | undefined {
+export function getLayoutFromConfig(config: ConfigWithLayout): Layout {
     // Backward compatibility for vertical option
-    return config.layout ?? (Boolean(config.vertical) ? "vertical" : undefined);
+    return config.layout ?? (Boolean(config.vertical) ? "vertical" : "default");
 }

--- a/src/utils/layout.ts
+++ b/src/utils/layout.ts
@@ -3,3 +3,12 @@ import { literal, union } from "superstruct";
 export type Layout = "vertical" | "horizontal";
 
 export const layoutStruct = union([literal("horizontal"), literal("vertical")]);
+
+type ConfigWithLayout = {
+    layout?: Layout;
+    [key: string]: any;
+};
+export function getLayoutFromConfig(config: ConfigWithLayout): Layout | undefined {
+    // Backward compatibility for vertical option
+    return config.layout ?? (Boolean(config.vertical) ? "vertical" : undefined);
+}

--- a/src/utils/lovelace/element-editor.ts
+++ b/src/utils/lovelace/element-editor.ts
@@ -215,12 +215,14 @@ export abstract class MushroomElementEditor<T> extends LitElement {
                               )}:"
                           >
                               ${this._warnings!.length > 0 && this._warnings![0] !== undefined
-                                  ? html` <ul>
-                                        ${this._warnings!.map(
-                                            (warning) => html`<li>${warning}</li>`
-                                        )}
-                                    </ul>`
-                                  : ""}
+                                  ? html`
+                                        <ul>
+                                            ${this._warnings!.map(
+                                                (warning) => html`<li>${warning}</li>`
+                                            )}
+                                        </ul>
+                                    `
+                                  : undefined}
                               ${this.hass.localize("ui.errors.config.edit_in_yaml_supported")}
                           </ha-alert>
                       `


### PR DESCRIPTION
# Description
Add different layout for all card : 
- default
- vertical
- horizontal

The `layout` option replace the `vertical` option. A backward compatibility is added.

fix #34 

# Some examples 
## Light card
![Capture d’écran 2022-02-17 à 19 11 18](https://user-images.githubusercontent.com/5878303/154544390-44958c37-6e13-4f34-8b49-851f7f4fedd0.png)
## Entity card
![Capture d’écran 2022-02-17 à 19 13 10](https://user-images.githubusercontent.com/5878303/154544574-e9dd4bc7-264b-473d-a310-a472b801b947.png)
## Fan card
![Capture d’écran 2022-02-17 à 19 11 11](https://user-images.githubusercontent.com/5878303/154544393-e2078b71-16db-4a27-b200-7511e8ba9148.png)
## Cover card
![Capture d’écran 2022-02-17 à 19 11 02](https://user-images.githubusercontent.com/5878303/154544394-052ae284-3533-4d81-8129-ff94bb3da821.png)
## Alarm card
![Capture d’écran 2022-02-17 à 19 14 11](https://user-images.githubusercontent.com/5878303/154544736-c544522c-b375-43b1-ae6f-af27da2a9041.png)

