### PR TITLE
fix: use same entity icons rules as home assistant frontend

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -10,13 +10,13 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import {
     alarmControlPanelCardCardConfigStruct,
     AlarmControlPanelCardConfig,
 } from "./alarm-control-panel-card-config";
 import { ALARM_CONTROl_PANEL_CARD_EDITOR_NAME, ALARM_CONTROl_PANEL_ENTITY_DOMAINS } from "./const";
-import { getStateIcon } from "./utils";
 
 const DOMAINS = [...ALARM_CONTROl_PANEL_ENTITY_DOMAINS];
 
@@ -46,8 +46,8 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
         }
 
         const dir = computeRTLDirection(this.hass);
-        const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;
-        const entityIcon = entityState ? getStateIcon(entityState.state) : undefined;
+        const entity = this._config.entity ? this.hass.states[this._config.entity] : undefined;
+        const entityIcon = entity ? stateIcon(entity) : undefined;
 
         const states = [
             "armed_home",

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -20,6 +20,8 @@ import "../../shared/state-item";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
+import { alarmPanelIconAction } from "../../utils/icons/alarm-panel-icon";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { getLayoutFromConfig } from "../../utils/layout";
 import { AlarmControlPanelCardConfig } from "./alarm-control-panel-card-config";
 import "./alarm-control-panel-card-editor";
@@ -30,7 +32,6 @@ import {
 } from "./const";
 import {
     getStateColor,
-    getStateIcon,
     getStateService,
     isActionsAvailable,
     isDisarmed,
@@ -142,7 +143,7 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
         const entity = this.hass.states[entity_id];
 
         const name = this._config.name ?? entity.attributes.friendly_name;
-        const icon = this._config.icon ?? getStateIcon(entity.state);
+        const icon = this._config.icon ?? stateIcon(entity);
         const color = getStateColor(entity.state);
         const shapePulse = shouldPulse(entity.state);
         const layout = getLayoutFromConfig(this._config);
@@ -209,7 +210,7 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
                                   ${actions.map(
                                       (action) => html`
                                           <mushroom-button
-                                              .icon=${getStateIcon(action.state)}
+                                              .icon=${alarmPanelIconAction(action.state)}
                                               @click=${(e) => this._onTap(e, action.state)}
                                               .disabled=${!isActionEnabled}
                                           ></mushroom-button>

--- a/src/cards/alarm-control-panel-card/const.ts
+++ b/src/cards/alarm-control-panel-card/const.ts
@@ -4,20 +4,6 @@ export const ALARM_CONTROl_PANEL_CARD_NAME = `${PREFIX_NAME}-alarm-control-panel
 export const ALARM_CONTROl_PANEL_CARD_EDITOR_NAME = `${ALARM_CONTROl_PANEL_CARD_NAME}-editor`;
 export const ALARM_CONTROl_PANEL_ENTITY_DOMAINS = ["alarm_control_panel"];
 
-export const ALARM_CONTROL_PANEL_CARD_STATE_ICON = {
-    disarmed: "mdi:shield-off-outline",
-    arming: "mdi:shield-sync-outline",
-    armed_away: "mdi:shield-lock-outline",
-    armed_home: "mdi:shield-home-outline",
-    armed_night: "mdi:shield-moon-outline",
-    armed_vacation: "mdi:shield-airplane-outline",
-    armed_custom_bypass: "mdi:shield-half-full",
-    pending: "mdi:shield-sync",
-    triggered: "mdi:bell-ring-outline",
-    unavailable: "mdi:bell-remove-outline",
-};
-export const ALARM_CONTROL_PANEL_CARD_DEFAULT_STATE_ICON = "mdi:shield-lock-outline";
-
 export const ALARM_CONTROL_PANEL_CARD_STATE_COLOR = {
     disarmed: "var(--rgb-state-alarm-disarmed)",
     armed: "var(--rgb-state-alarm-armed)",
@@ -35,7 +21,3 @@ export const ALARM_CONTROL_PANEL_CARD_STATE_SERVICE = {
     armed_vacation: "alarm_arm_vacation",
     armed_custom_bypass: "alarm_arm_custom_bypass",
 };
-
-/*
-armed_away, armed_home, armed_night, arming, disarmed, pending, triggered and unavailable
-*/

--- a/src/cards/alarm-control-panel-card/utils.ts
+++ b/src/cards/alarm-control-panel-card/utils.ts
@@ -1,9 +1,7 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import {
     ALARM_CONTROL_PANEL_CARD_DEFAULT_STATE_COLOR,
-    ALARM_CONTROL_PANEL_CARD_DEFAULT_STATE_ICON,
     ALARM_CONTROL_PANEL_CARD_STATE_COLOR,
-    ALARM_CONTROL_PANEL_CARD_STATE_ICON,
     ALARM_CONTROL_PANEL_CARD_STATE_SERVICE,
 } from "./const";
 
@@ -14,18 +12,12 @@ export function getStateColor(state: string): string {
     );
 }
 
-export function getStateIcon(state: string): string {
-    return (
-        ALARM_CONTROL_PANEL_CARD_STATE_ICON[state] || ALARM_CONTROL_PANEL_CARD_DEFAULT_STATE_ICON
-    );
-}
-
 export function getStateService(state: string): string | undefined {
     return ALARM_CONTROL_PANEL_CARD_STATE_SERVICE[state];
 }
 
-export function shouldPulse(state:string): boolean {
-    return ["arming", "triggered", "pending", "unavailable"].indexOf(state) >= 0
+export function shouldPulse(state: string): boolean {
+    return ["arming", "triggered", "pending", "unavailable"].indexOf(state) >= 0;
 }
 
 export function isActionsAvailable(entity: HassEntity) {

--- a/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
@@ -1,10 +1,11 @@
-import { fireEvent, HomeAssistant, stateIcon } from "custom-card-helpers";
+import { fireEvent, HomeAssistant } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import setupCustomlocalize from "../../../localize";
 import "../../../shared/editor/color-picker";
 import "../../../shared/editor/info-picker";
 import { configElementStyle } from "../../../utils/editor-styles";
+import { stateIcon } from "../../../utils/icons/state-icon";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { AlarmControlPanelChipConfig } from "../../../utils/lovelace/chip/types";
 import { EditorTarget } from "../../../utils/lovelace/editor/types";

--- a/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
@@ -68,6 +68,17 @@ export class AlarmControlPanelChipEditor extends LitElement implements LovelaceC
                     </mushroom-info-picker>
                 </div>
                 <div class="side-by-side">
+                    <ha-icon-picker
+                        .label="${this.hass.localize(
+                            "ui.panel.lovelace.editor.card.generic.icon"
+                        )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"
+                        .value=${this._config.icon}
+                        .placeholder=${this._config.icon || entityIcon}
+                        .configValue=${"icon"}
+                        @value-changed=${this._valueChanged}
+                    ></ha-icon-picker>
+                </div>
+                <div class="side-by-side">
                     <hui-action-editor
                         .label="${this.hass.localize(
                             "ui.panel.lovelace.editor.card.generic.tap_action"

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -12,15 +12,20 @@ import { styleMap } from "lit/directives/style-map.js";
 import { computeRgbColor } from "../../../utils/colors";
 import { actionHandler } from "../../../utils/directives/action-handler-directive";
 import { animation } from "../../../utils/entity-styles";
+import { stateIcon } from "../../../utils/icons/state-icon";
 import { getInfo } from "../../../utils/info";
 import {
     computeChipComponentName,
     computeChipEditorComponentName,
 } from "../../../utils/lovelace/chip/chip-element";
-import { AlarmControlPanelChipConfig, EntityChipConfig, LovelaceChip } from "../../../utils/lovelace/chip/types";
+import {
+    AlarmControlPanelChipConfig,
+    EntityChipConfig,
+    LovelaceChip,
+} from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 import { ALARM_CONTROl_PANEL_ENTITY_DOMAINS } from "../../alarm-control-panel-card/const";
-import { getStateColor, getStateIcon, shouldPulse } from "../../alarm-control-panel-card/utils";
+import { getStateColor, shouldPulse } from "../../alarm-control-panel-card/utils";
 import "./alarm-control-panel-chip-editor";
 
 @customElement(computeChipComponentName("alarm-control-panel"))
@@ -63,7 +68,7 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
         const entity = this.hass.states[entity_id];
 
         const name = this._config.name ?? entity.attributes.friendly_name ?? "";
-        const icon = this._config.icon ?? getStateIcon(entity.state);
+        const icon = this._config.icon ?? stateIcon(entity);
         const iconColor = getStateColor(entity.state);
         const iconPulse = shouldPulse(entity.state);
 

--- a/src/cards/chips-card/chips/entity-chip-editor.ts
+++ b/src/cards/chips-card/chips/entity-chip-editor.ts
@@ -1,10 +1,11 @@
-import { fireEvent, HomeAssistant, stateIcon } from "custom-card-helpers";
+import { fireEvent, HomeAssistant } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import setupCustomlocalize from "../../../localize";
 import "../../../shared/editor/color-picker";
 import "../../../shared/editor/info-picker";
 import { configElementStyle } from "../../../utils/editor-styles";
+import { stateIcon } from "../../../utils/icons/state-icon";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { EntityChipConfig } from "../../../utils/lovelace/chip/types";
 import { EditorTarget } from "../../../utils/lovelace/editor/types";

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -4,7 +4,6 @@ import {
     handleAction,
     hasAction,
     HomeAssistant,
-    stateIcon,
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -13,6 +12,7 @@ import { styleMap } from "lit/directives/style-map.js";
 import { computeRgbColor } from "../../../utils/colors";
 import { actionHandler } from "../../../utils/directives/action-handler-directive";
 import { isActive } from "../../../utils/entity";
+import { stateIcon } from "../../../utils/icons/state-icon";
 import { getInfo } from "../../../utils/info";
 import {
     computeChipComponentName,

--- a/src/cards/chips-card/chips/light-chip-editor.ts
+++ b/src/cards/chips-card/chips/light-chip-editor.ts
@@ -1,9 +1,10 @@
-import { computeRTLDirection, fireEvent, HomeAssistant, stateIcon } from "custom-card-helpers";
+import { computeRTLDirection, fireEvent, HomeAssistant } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import setupCustomlocalize from "../../../localize";
 import "../../../shared/editor/info-picker";
 import { configElementStyle } from "../../../utils/editor-styles";
+import { stateIcon } from "../../../utils/icons/state-icon";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { LightChipConfig } from "../../../utils/lovelace/chip/types";
 import { EditorTarget } from "../../../utils/lovelace/editor/types";

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -4,7 +4,6 @@ import {
     handleAction,
     hasAction,
     HomeAssistant,
-    stateIcon,
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -12,6 +11,7 @@ import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { actionHandler } from "../../../utils/directives/action-handler-directive";
 import { isActive } from "../../../utils/entity";
+import { stateIcon } from "../../../utils/icons/state-icon";
 import { getInfo } from "../../../utils/info";
 import {
     computeChipComponentName,

--- a/src/cards/cover-card/controls/cover-buttons-control.ts
+++ b/src/cards/cover-card/controls/cover-buttons-control.ts
@@ -4,6 +4,7 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import "../../../shared/button";
+import { computeCloseIcon, computeOpenIcon } from "../../../utils/icons/cover-icon";
 import { isClosing, isFullyClosed, isFullyOpen, isOpening } from "../utils";
 
 @customElement("mushroom-cover-buttons-control")
@@ -44,13 +45,13 @@ export class CoverButtonsControl extends LitElement {
                 })}
             >
                 <mushroom-button
-                    icon="mdi:arrow-down"
+                    .icon=${computeCloseIcon(this.entity)}
                     .disabled=${isFullyClosed(this.entity) || isClosing(this.entity)}
                     @click=${this._onCloseTap}
                 ></mushroom-button>
                 <mushroom-button icon="mdi:pause" @click=${this._onStopTap}></mushroom-button>
                 <mushroom-button
-                    icon="mdi:arrow-up"
+                    .icon=${computeOpenIcon(this.entity)}
                     .disabled=${isFullyOpen(this.entity) || isOpening(this.entity)}
                     @click=${this._onOpenTap}
                 ></mushroom-button>

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -3,7 +3,6 @@ import {
     fireEvent,
     HomeAssistant,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -11,6 +10,7 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { COVER_CARD_EDITOR_NAME, COVER_ENTITY_DOMAINS } from "./const";
 import { CoverCardConfig, coverCardConfigStruct } from "./cover-card-config";

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -6,7 +6,6 @@ import {
     HomeAssistant,
     LovelaceCard,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
@@ -21,6 +20,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive } from "../../utils/entity";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { getLayoutFromConfig, Layout } from "../../utils/layout";
 import { COVER_CARD_EDITOR_NAME, COVER_CARD_NAME, COVER_ENTITY_DOMAINS } from "./const";
 import "./controls/cover-buttons-control";

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -3,7 +3,6 @@ import {
     fireEvent,
     HomeAssistant,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -13,6 +12,7 @@ import "../../shared/editor/color-picker";
 import "../../shared/editor/info-picker";
 import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { ENTITY_CARD_EDITOR_NAME } from "./const";
 import { EntityCardConfig, entityCardConfigStruct } from "./entity-card-config";

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -6,7 +6,6 @@ import {
     HomeAssistant,
     LovelaceCard,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -21,6 +20,7 @@ import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive, isAvailable } from "../../utils/entity";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { getInfo } from "../../utils/info";
 import { getLayoutFromConfig } from "../../utils/layout";
 import { ENTITY_CARD_EDITOR_NAME, ENTITY_CARD_NAME } from "./const";

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -3,7 +3,6 @@ import {
     fireEvent,
     HomeAssistant,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -11,6 +10,7 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import { FanCardConfig, fanCardConfigStruct } from "./fan-card-config";

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -6,7 +6,6 @@ import {
     HomeAssistant,
     LovelaceCard,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -22,6 +21,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive, isAvailable } from "../../utils/entity";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { getLayoutFromConfig } from "../../utils/layout";
 import { FAN_CARD_EDITOR_NAME, FAN_CARD_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import "./controls/fan-oscillate-control";

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -3,7 +3,6 @@ import {
     fireEvent,
     HomeAssistant,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -11,6 +10,7 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
 import { LightCardConfig, lightCardConfigStruct } from "./light-card-config";

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -6,7 +6,6 @@ import {
     HomeAssistant,
     LovelaceCard,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { HassEntity } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
@@ -22,6 +21,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive } from "../../utils/entity";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { getLayoutFromConfig } from "../../utils/layout";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_CARD_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
 import "./controls/light-brightness-control";

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -3,7 +3,6 @@ import {
     fireEvent,
     HomeAssistant,
     LovelaceCardEditor,
-    stateIcon,
 } from "custom-card-helpers";
 import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -11,6 +10,7 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/layout-picker";
 import { configElementStyle } from "../../utils/editor-styles";
+import { stateIcon } from "../../utils/icons/state-icon";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { PERSON_CARD_EDITOR_NAME, PERSON_ENTITY_DOMAINS } from "./const";
 import { PersonCardConfig, personCardConfigStruct } from "./person-card-config";

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -6,7 +6,6 @@ import {
     HomeAssistant,
     LovelaceCard,
     LovelaceCardEditor,
-    stateIcon as stateIconHelper,
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
@@ -19,6 +18,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { isActive } from "../../utils/entity";
+import { stateIcon as stateIconHelper } from "../../utils/icons/state-icon";
 import { getLayoutFromConfig } from "../../utils/layout";
 import { PERSON_CARD_EDITOR_NAME, PERSON_CARD_NAME, PERSON_ENTITY_DOMAINS } from "./const";
 import { PersonCardConfig } from "./person-card-config";

--- a/src/utils/icons/alarm-panel-icon.ts
+++ b/src/utils/icons/alarm-panel-icon.ts
@@ -11,12 +11,32 @@ export const alarmPanelIcon = (state?: string) => {
         case "armed_custom_bypass":
             return "mdi:security";
         case "pending":
-            return "mdi:shield-outline";
+        case "arming":
+            return "mdi:shield-sync";
         case "triggered":
             return "mdi:bell-ring";
         case "disarmed":
             return "mdi:shield-off";
         default:
             return "mdi:shield";
+    }
+};
+
+export const alarmPanelIconAction = (state?: string) => {
+    switch (state) {
+        case "armed_away":
+            return "mdi:shield-lock-outline";
+        case "armed_vacation":
+            return "mdi:shield-airplane-outline";
+        case "armed_home":
+            return "mdi:shield-home-outline";
+        case "armed_night":
+            return "mdi:shield-moon-outline";
+        case "armed_custom_bypass":
+            return "mdi:shield-half-full";
+        case "disarmed":
+            return "mdi:shield-off-outline";
+        default:
+            return "mdi:shield-outline";
     }
 };

--- a/src/utils/icons/alarm-panel-icon.ts
+++ b/src/utils/icons/alarm-panel-icon.ts
@@ -1,0 +1,22 @@
+export const alarmPanelIcon = (state?: string) => {
+    switch (state) {
+        case "armed_away":
+            return "mdi:shield-lock";
+        case "armed_vacation":
+            return "mdi:shield-airplane";
+        case "armed_home":
+            return "mdi:shield-home";
+        case "armed_night":
+            return "mdi:shield-moon";
+        case "armed_custom_bypass":
+            return "mdi:security";
+        case "pending":
+            return "mdi:shield-outline";
+        case "triggered":
+            return "mdi:bell-ring";
+        case "disarmed":
+            return "mdi:shield-off";
+        default:
+            return "mdi:shield";
+    }
+};

--- a/src/utils/icons/binary-sensor-icon.ts
+++ b/src/utils/icons/binary-sensor-icon.ts
@@ -1,0 +1,58 @@
+import { HassEntity } from "home-assistant-js-websocket";
+
+export const binarySensorIcon = (state?: string, entity?: HassEntity) => {
+    const isOff = state === "off";
+    switch (entity?.attributes.device_class) {
+        case "battery":
+            return isOff ? "mdi:battery" : "mdi:battery-outline";
+        case "battery_charging":
+            return isOff ? "mdi:battery" : "mdi:battery-charging";
+        case "cold":
+            return isOff ? "mdi:thermometer" : "mdi:snowflake";
+        case "connectivity":
+            return isOff ? "mdi:close-network-outline" : "mdi:check-network-outline";
+        case "door":
+            return isOff ? "mdi:door-closed" : "mdi:door-open";
+        case "garage_door":
+            return isOff ? "mdi:garage" : "mdi:garage-open";
+        case "power":
+            return isOff ? "mdi:power-plug-off" : "mdi:power-plug";
+        case "gas":
+        case "problem":
+        case "safety":
+        case "tamper":
+            return isOff ? "mdi:check-circle" : "mdi:alert-circle";
+        case "smoke":
+            return isOff ? "mdi:check-circle" : "mdi:smoke";
+        case "heat":
+            return isOff ? "mdi:thermometer" : "mdi:fire";
+        case "light":
+            return isOff ? "mdi:brightness5" : "mdi:brightness-7";
+        case "lock":
+            return isOff ? "mdi:lock" : "mdi:lock-open";
+        case "moisture":
+            return isOff ? "mdi:water-off" : "mdi:water";
+        case "motion":
+            return isOff ? "mdi:motion-sensor-off" : "mdi:motion-sensor";
+        case "occupancy":
+            return isOff ? "mdi:home-outline" : "mdi:home";
+        case "opening":
+            return isOff ? "mdi:square" : "mdi:square-outline";
+        case "plug":
+            return isOff ? "mdi:power-plug-off" : "mdi:power-plug";
+        case "presence":
+            return isOff ? "mdi:home-outline" : "mdi:home";
+        case "running":
+            return isOff ? "mdi:stop" : "mdi:play";
+        case "sound":
+            return isOff ? "mdi:music-note-off" : "mdi:music-note";
+        case "update":
+            return isOff ? "mdi:package" : "mdi:package-up";
+        case "vibration":
+            return isOff ? "mdi:crop-portrait" : "mdi:vibrate";
+        case "window":
+            return isOff ? "mdi:window-closed" : "mdi:window-open";
+        default:
+            return isOff ? "mdi:radiobox-blank" : "mdi:checkbox-marked-circle";
+    }
+};

--- a/src/utils/icons/cover-icon.ts
+++ b/src/utils/icons/cover-icon.ts
@@ -1,0 +1,111 @@
+import { HassEntity } from "home-assistant-js-websocket";
+
+export const coverIcon = (state?: string, entity?: HassEntity): string => {
+    const open = state !== "closed";
+
+    switch (entity?.attributes.device_class) {
+        case "garage":
+            switch (state) {
+                case "opening":
+                    return "mdi:arrow-up-box";
+                case "closing":
+                    return "mdi:arrow-down-box";
+                case "closed":
+                    return "mdi:garage";
+                default:
+                    return "mdi:garage-open";
+            }
+        case "gate":
+            switch (state) {
+                case "opening":
+                case "closing":
+                    return "mdi:gate-arrow-right";
+                case "closed":
+                    return "mdi:gate";
+                default:
+                    return "mdi:gate-open";
+            }
+        case "door":
+            return open ? "mdi:door-open" : "mdi:door-closed";
+        case "damper":
+            return open ? "md:circle" : "mdi:circle-slice-8";
+        case "shutter":
+            switch (state) {
+                case "opening":
+                    return "mdi:arrow-up-box";
+                case "closing":
+                    return "mdi:arrow-down-box";
+                case "closed":
+                    return "mdi:window-shutter";
+                default:
+                    return "mdi:window-shutter-open";
+            }
+        case "curtain":
+            switch (state) {
+                case "opening":
+                    return "mdi:arrow-split-vertical";
+                case "closing":
+                    return "mdi:arrow-collapse-horizontal";
+                case "closed":
+                    return "mdi:curtains-closed";
+                default:
+                    return "mdi:curtains";
+            }
+        case "blind":
+        case "shade":
+            switch (state) {
+                case "opening":
+                    return "mdi:arrow-up-box";
+                case "closing":
+                    return "mdi:arrow-down-box";
+                case "closed":
+                    return "mdi:blinds";
+                default:
+                    return "mdi:blinds-open";
+            }
+        case "window":
+            switch (state) {
+                case "opening":
+                    return "mdi:arrow-up-box";
+                case "closing":
+                    return "mdi:arrow-down-box";
+                case "closed":
+                    return "mdi:window-closed";
+                default:
+                    return "mdi:window-open";
+            }
+    }
+
+    switch (state) {
+        case "opening":
+            return "mdi:arrow-up-box";
+        case "closing":
+            return "mdi:arrow-down-box";
+        case "closed":
+            return "mdi:window-closed";
+        default:
+            return "mdi:window-open";
+    }
+};
+
+export const computeOpenIcon = (stateObj: HassEntity): string => {
+    switch (stateObj.attributes.device_class) {
+        case "awning":
+        case "door":
+        case "gate":
+            return "mdi:arrow-expand-horizontal";
+        default:
+            return "mdi:arrow-up";
+    }
+};
+
+export const computeCloseIcon = (stateObj: HassEntity): string => {
+    switch (stateObj.attributes.device_class) {
+        case "awning":
+        case "door":
+        case "gate":
+            return "mdi:arrow-collapse-horizontal";
+        default:
+            return "mdi:arrow-down";
+    }
+};

--- a/src/utils/icons/domain-icon.ts
+++ b/src/utils/icons/domain-icon.ts
@@ -1,0 +1,159 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { alarmPanelIcon } from "./alarm-panel-icon";
+import { binarySensorIcon } from "./binary-sensor-icon";
+import { coverIcon } from "./cover-icon";
+import { sensorIcon } from "./sensor-icon";
+
+const DEFAULT_DOMAIN_ICON = "mdi:bookmark";
+
+const FIXED_DOMAIN_ICONS = {
+    alert: "mdi:alert",
+    air_quality: "mdi:air-filter",
+    automation: "mdi:robot",
+    calendar: "mdi:calendar",
+    camera: "mdi:video",
+    climate: "mdi:thermostat",
+    configurator: "mdi:cog",
+    conversation: "mdi:text-to-speech",
+    counter: "mdi:counter",
+    fan: "mdi:fan",
+    google_assistant: "mdi:google-assistant",
+    group: "mdi:google-circles-communities",
+    homeassistant: "mdi:home-assistant",
+    homekit: "mdi:home-automation",
+    image_processing: "mdi:image-filter-frames",
+    input_button: "mdi:gesture-tap-button",
+    input_datetime: "mdi:calendar-clock",
+    input_number: "mdi:ray-vertex",
+    input_select: "mdi:format-list-bulleted",
+    input_text: "mdi:form-textbox",
+    light: "mdi:lightbulb",
+    mailbox: "mdi:mailbox",
+    notify: "mdi:comment-alert",
+    number: "mdi:ray-vertex",
+    persistent_notification: "mdi:bell",
+    person: "mdi:account",
+    plant: "mdi:flower",
+    proximity: "mdi:apple-safari",
+    remote: "mdi:remote",
+    scene: "mdi:palette",
+    script: "mdi:script-text",
+    select: "mdi:format-list-bulleted",
+    sensor: "mdi:eye",
+    siren: "mdi:bullhorn",
+    simple_alarm: "mdi:bell",
+    sun: "mdi:white-balance-sunny",
+    timer: "mdi:timer-outline",
+    updater: "mdi:cloud-upload",
+    vacuum: "mdi:robot-vacuum",
+    water_heater: "mdi:thermometer",
+    weather: "mdi:weather-cloudy",
+    zone: "mdi:map-marker-radius",
+};
+
+export function domainIcon(domain: string, entity?: HassEntity, state?: string): string {
+    switch (domain) {
+        case "alarm_control_panel":
+            return alarmPanelIcon(state);
+
+        case "binary_sensor":
+            return binarySensorIcon(state, entity);
+
+        case "button":
+            switch (entity?.attributes.device_class) {
+                case "restart":
+                    return "mdi:restart";
+                case "update":
+                    return "mdi:package-up";
+                default:
+                    return "mdi:gesture-tap-button";
+            }
+
+        case "cover":
+            return coverIcon(state, entity);
+
+        case "device_tracker":
+            if (entity?.attributes.source_type === "router") {
+                return state === "home" ? "mdi:lan-connect" : "mdi:lan-disconnect";
+            }
+            if (["bluetooth", "bluetooth_le"].includes(entity?.attributes.source_type)) {
+                return state === "home" ? "mdi:bluetooth-connect" : "mdi:bluetooth";
+            }
+            return state === "not_home" ? "mdi:account-arrow-right" : "mdi:account";
+
+        case "humidifier":
+            return state && state === "off" ? "mdi:air-humidifier-off" : "mdi:air-humidifier";
+
+        case "input_boolean":
+            return state === "on" ? "mdi:check-circle-outline" : "mdi:close-circle-outline";
+
+        case "lock":
+            switch (state) {
+                case "unlocked":
+                    return "mdi:lock-open";
+                case "jammed":
+                    return "mdi:lock-alert";
+                case "locking":
+                case "unlocking":
+                    return "mdi:lock-clock";
+                default:
+                    return "mdi:lock";
+            }
+
+        case "media_player":
+            return state === "playing" ? "mdi:cast-connected" : "mdi:cast";
+
+        case "switch":
+            switch (entity?.attributes.device_class) {
+                case "outlet":
+                    return state === "on" ? "mdi:power-plug" : "mdi:power-plug-off";
+                case "switch":
+                    return state === "on" ? "mdi:toggle-switch" : "mdi:toggle-switch-off";
+                default:
+                    return "mdi:flash";
+            }
+
+        case "zwave":
+            switch (state) {
+                case "dead":
+                    return "mdi:emoticon-dead";
+                case "sleeping":
+                    return "mdi:sleep";
+                case "initializing":
+                    return "mdi:timer-sand";
+                default:
+                    return "mdi:z-wave";
+            }
+
+        case "sensor": {
+            const icon = sensorIcon(entity);
+            if (icon) {
+                return icon;
+            }
+
+            break;
+        }
+
+        case "input_datetime":
+            if (!entity?.attributes.has_date) {
+                return "mdi:clock";
+            }
+            if (!entity.attributes.has_time) {
+                return "mdi:calendar";
+            }
+            break;
+
+        case "sun":
+            return entity?.state === "above_horizon"
+                ? FIXED_DOMAIN_ICONS[domain]
+                : "mdi:weather-night";
+    }
+
+    if (domain in FIXED_DOMAIN_ICONS) {
+        return FIXED_DOMAIN_ICONS[domain];
+    }
+
+    // eslint-disable-next-line
+    console.warn(`Unable to find icon for domain ${domain}`);
+    return DEFAULT_DOMAIN_ICON;
+}

--- a/src/utils/icons/sensor-icon.ts
+++ b/src/utils/icons/sensor-icon.ts
@@ -1,0 +1,112 @@
+import { UNIT_C, UNIT_F } from "custom-card-helpers";
+import { HassEntity } from "home-assistant-js-websocket";
+
+const FIXED_DEVICE_CLASS_ICONS = {
+    apparent_power: "mdi:flash",
+    aqi: "mdi:air-filter",
+    carbon_dioxide: "mdi:molecule-co2",
+    carbon_monoxide: "mdi:molecule-co",
+    current: "mdi:current-ac",
+    date: "mdi:calendar",
+    energy: "mdi:lightning-bolt",
+    frequency: "mdi:sine-wave",
+    gas: "mdi:gas-cylinder",
+    humidity: "mdi:water-percent",
+    illuminance: "mdi:brightness-5",
+    monetary: "mdi:cash",
+    nitrogen_dioxide: "mdi:molecule",
+    nitrogen_monoxide: "mdi:molecule",
+    nitrous_oxide: "mdi:molecule",
+    ozone: "mdi:molecule",
+    pm1: "mdi:molecule",
+    pm10: "mdi:molecule",
+    pm25: "mdi:molecule",
+    power: "mdi:flash",
+    power_factor: "mdi:angle-acute",
+    pressure: "mdi:gauge",
+    reactive_power: "mdi:flash",
+    signal_strength: "mdi:wifi",
+    sulphur_dioxide: "mdi:molecule",
+    temperature: "mdi:thermometer",
+    timestamp: "mdi:clock",
+    volatile_organic_compounds: "mdi:molecule",
+    voltage: "mdi:sine-wave",
+};
+
+const SENSOR_DEVICE_CLASS_BATTERY = "battery";
+
+const BATTERY_ICONS = {
+    10: "mdi:battery-10",
+    20: "mdi:battery-20",
+    30: "mdi:battery-30",
+    40: "mdi:battery-40",
+    50: "mdi:battery-50",
+    60: "mdi:battery-60",
+    70: "mdi:battery-70",
+    80: "mdi:battery-80",
+    90: "mdi:battery-90",
+    100: "mdi:battery",
+};
+const BATTERY_CHARGING_ICONS = {
+    10: "mdi:battery-charging-10",
+    20: "mdi:battery-charging-20",
+    30: "mdi:battery-charging-30",
+    40: "mdi:battery-charging-40",
+    50: "mdi:battery-charging-50",
+    60: "mdi:battery-charging-60",
+    70: "mdi:battery-charging-70",
+    80: "mdi:battery-charging-80",
+    90: "mdi:battery-charging-90",
+    100: "mdi:battery-charging",
+};
+
+const batteryStateIcon = (batteryEntity: HassEntity, batteryChargingEntity?: HassEntity) => {
+    const battery = batteryEntity.state;
+    const batteryCharging = batteryChargingEntity?.state === "on";
+
+    return batteryIcon(battery, batteryCharging);
+};
+
+export const batteryIcon = (batteryState: number | string, batteryCharging?: boolean) => {
+    const batteryValue = Number(batteryState);
+    if (isNaN(batteryValue)) {
+        if (batteryState === "off") {
+            return "mdi:battery";
+        }
+        if (batteryState === "on") {
+            return "mdi:battery-alert";
+        }
+        return "mdi:battery-unknown";
+    }
+
+    const batteryRound = Math.round(batteryValue / 10) * 10;
+    if (batteryCharging && batteryValue >= 10) {
+        return BATTERY_CHARGING_ICONS[batteryRound];
+    }
+    if (batteryCharging) {
+        return "mdi:battery-charging-outline";
+    }
+    if (batteryValue <= 5) {
+        return "mdi:battery-alert-variant-outline";
+    }
+    return BATTERY_ICONS[batteryRound];
+};
+
+export const sensorIcon = (entity?: HassEntity): string | undefined => {
+    const dclass = entity?.attributes.device_class;
+
+    if (dclass && dclass in FIXED_DEVICE_CLASS_ICONS) {
+        return FIXED_DEVICE_CLASS_ICONS[dclass];
+    }
+
+    if (dclass === SENSOR_DEVICE_CLASS_BATTERY) {
+        return entity ? batteryStateIcon(entity) : "mdi:battery";
+    }
+
+    const unit = entity?.attributes.unit_of_measurement;
+    if (unit === UNIT_C || unit === UNIT_F) {
+        return "mdi:thermometer";
+    }
+
+    return undefined;
+};

--- a/src/utils/icons/state-icon.ts
+++ b/src/utils/icons/state-icon.ts
@@ -1,0 +1,11 @@
+import { computeDomain } from "custom-card-helpers";
+import { HassEntity } from "home-assistant-js-websocket";
+import { domainIcon } from "./domain-icon";
+
+export function stateIcon(entity: HassEntity): string {
+    const domain = computeDomain(entity.entity_id);
+
+    const state = entity.state;
+
+    return domainIcon(domain, entity, state);
+}


### PR DESCRIPTION
https://github.com/custom-cards/custom-card-helpers is not very active. I imported the icon rules from HA front-end.

fix #87
fix #125 
fix #145 