### PR TITLE
feat(template): add entity in template card and chip

### DIFF
--- a/src/cards/chips-card/chips-card-editor.ts
+++ b/src/cards/chips-card/chips-card-editor.ts
@@ -98,6 +98,7 @@ const lightChipConfigStruct = object({
 
 const templateChipConfigStruct = object({
     type: literal("template"),
+    entity: optional(string()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),

--- a/src/cards/chips-card/chips/template-chip-editor.ts
+++ b/src/cards/chips-card/chips/template-chip-editor.ts
@@ -9,7 +9,7 @@ import { TemplateChipConfig } from "../../../utils/lovelace/chip/types";
 import { EditorTarget } from "../../../utils/lovelace/editor/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 
-const actions = ["navigate", "url", "call-service", "none"];
+const actions = ["toggle", "more-info", "navigate", "url", "call-service", "none"];
 
 @customElement(computeChipEditorComponentName("template"))
 export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
@@ -30,6 +30,16 @@ export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
 
         return html`
             <div class="card-config">
+                <ha-entity-picker
+                    .label="${this.hass.localize(
+                        "ui.panel.lovelace.editor.card.generic.entity"
+                    )}  (${customLocalize("editor.card.template.entity_extra")})"
+                    .hass=${this.hass}
+                    .value=${this._config.entity}
+                    .configValue=${"entity"}
+                    @value-changed=${this._valueChanged}
+                    allow-custom-entity
+                ></ha-entity-picker>
                 <mushroom-textarea
                     .label="${customLocalize("editor.chip.template.content")} (${this.hass.localize(
                         "ui.panel.lovelace.editor.card.config.optional"

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -43,11 +43,22 @@ export class TemplateChip extends LitElement implements LovelaceChip {
 
     public setConfig(config: TemplateChipConfig): void {
         TEMPLATE_KEYS.forEach((key) => {
-            if (this._config?.[key] !== config[key]) {
+            if (this._config?.[key] !== config[key] || this._config?.entity != config.entity) {
                 this._tryDisconnectKey(key);
             }
         });
-        this._config = config;
+        this._config = {
+            tap_action: {
+                action: "toggle",
+            },
+            hold_action: {
+                action: "more-info",
+            },
+            double_tap_action: {
+                action: "more-info",
+            },
+            ...config,
+        };
     }
 
     public connectedCallback() {
@@ -148,6 +159,7 @@ export class TemplateChip extends LitElement implements LovelaceChip {
                     variables: {
                         config: this._config,
                         user: this.hass.user!.name,
+                        entity: this._config.entity,
                     },
                 }
             );

--- a/src/cards/template-card/template-card-config.ts
+++ b/src/cards/template-card/template-card-config.ts
@@ -5,6 +5,7 @@ import { baseLovelaceCardConfig } from "../../utils/editor-styles";
 import { Layout, layoutStruct } from "../../utils/layout";
 
 export interface TemplateCardConfig extends LovelaceCardConfig {
+    entity?: string;
     icon?: string;
     icon_color?: string;
     primary?: string;
@@ -20,6 +21,7 @@ export interface TemplateCardConfig extends LovelaceCardConfig {
 export const templateCardConfigStruct = assign(
     baseLovelaceCardConfig,
     object({
+        entity: optional(string()),
         icon: optional(string()),
         icon_color: optional(string()),
         primary: optional(string()),

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -15,7 +15,7 @@ import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { TEMPLATE_CARD_EDITOR_NAME } from "./const";
 import { TemplateCardConfig, templateCardConfigStruct } from "./template-card-config";
 
-const actions = ["navigate", "url", "call-service", "none"];
+const actions = ["toggle", "more-info", "navigate", "url", "call-service", "none"];
 
 @customElement(TEMPLATE_CARD_EDITOR_NAME)
 export class TemplateCardEditor extends LitElement implements LovelaceCardEditor {
@@ -38,7 +38,17 @@ export class TemplateCardEditor extends LitElement implements LovelaceCardEditor
 
         return html`
             <div class="card-config">
-                <mushroom-textarea
+                <ha-entity-picker
+                    .label="${this.hass.localize(
+                        "ui.panel.lovelace.editor.card.generic.entity"
+                    )} (${customLocalize("editor.card.template.entity_extra")})"
+                    .hass=${this.hass}
+                    .value=${this._config.entity}
+                    .configValue=${"entity"}
+                    @value-changed=${this._valueChanged}
+                    allow-custom-entity
+                ></ha-entity-picker
+                ><mushroom-textarea
                     .label="${this.hass.localize(
                         "ui.panel.lovelace.editor.card.generic.icon"
                     )} (${this.hass.localize("ui.panel.lovelace.editor.card.config.optional")})"

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -63,7 +63,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
 
     setConfig(config: TemplateCardConfig): void {
         TEMPLATE_KEYS.forEach((key) => {
-            if (this._config?.[key] !== config[key]) {
+            if (this._config?.[key] !== config[key] || this._config?.entity != config.entity) {
                 this._tryDisconnectKey(key);
             }
         });
@@ -205,6 +205,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
                     variables: {
                         config: this._config,
                         user: this.hass.user!.name,
+                        entity: this._config.entity,
                     },
                 }
             );

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -62,7 +62,8 @@
             },
             "template": {
                 "primary": "Primary information",
-                "secondary": "Secondary information"
+                "secondary": "Secondary information",
+                "entity_extra": "Used in templates and actions"
             },
             "title": {
                 "title": "Title",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -62,7 +62,8 @@
             },
             "template": {
                 "primary": "Information principale",
-                "secondary": "Information secondaire"
+                "secondary": "Information secondaire",
+                "entity_extra": "Utilisée pour les templates et les actions"
             },
             "title": {
                 "title": "Titre",

--- a/src/utils/lovelace/chip/types.ts
+++ b/src/utils/lovelace/chip/types.ts
@@ -63,6 +63,7 @@ export type WeatherChipConfig = {
 
 export type TemplateChipConfig = {
     type: "template";
+    entity?: string;
     hold_action?: ActionConfig;
     tap_action?: ActionConfig;
     double_tap_action?: ActionConfig;


### PR DESCRIPTION
It is now possible to use entity in template

```
{{ states(entity) }}
```

The `more-info` and `toggle` action use this entity too.