### PR TITLE
fix(ha): hack to load ha component

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -13,6 +13,7 @@ import "../../shared/form/mushroom-select";
 import "../../shared/form/mushroom-textfield";
 import { configElementStyle } from "../../utils/editor-styles";
 import { stateIcon } from "../../utils/icons/state-icon";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import {
     alarmControlPanelCardCardConfigStruct,
@@ -32,6 +33,10 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: AlarmControlPanelCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: AlarmControlPanelCardConfig): void {
         assert(config, alarmControlPanelCardCardConfigStruct);

--- a/src/cards/chips-card/chips-card-editor.ts
+++ b/src/cards/chips-card/chips-card-editor.ts
@@ -18,6 +18,7 @@ import setupCustomlocalize from "../../localize";
 import "../../shared/editor/alignment-picker";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
+import { loadHaComponents } from "../../utils/loader";
 import { LovelaceChipConfig } from "../../utils/lovelace/chip/types";
 import {
     EditorTarget,
@@ -146,6 +147,10 @@ export class ChipsCardEditor extends LitElement implements LovelaceCardEditor {
     @state() private _config?: ChipsCardConfig;
 
     @state() private _subElementEditorConfig?: SubElementEditorConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: ChipsCardConfig): void {
         assert(config, cardConfigStruct);

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -12,6 +12,7 @@ import "../../shared/editor/layout-picker";
 import "../../shared/form/mushroom-textfield";
 import { configElementStyle } from "../../utils/editor-styles";
 import { stateIcon } from "../../utils/icons/state-icon";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { COVER_CARD_EDITOR_NAME, COVER_ENTITY_DOMAINS } from "./const";
 import { CoverCardConfig, coverCardConfigStruct } from "./cover-card-config";
@@ -23,6 +24,10 @@ export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: CoverCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: CoverCardConfig): void {
         assert(config, coverCardConfigStruct);

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -14,6 +14,7 @@ import "../../shared/editor/layout-picker";
 import "../../shared/form/mushroom-textfield";
 import { configElementStyle } from "../../utils/editor-styles";
 import { stateIcon } from "../../utils/icons/state-icon";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { ENTITY_CARD_EDITOR_NAME } from "./const";
 import { EntityCardConfig, entityCardConfigStruct } from "./entity-card-config";
@@ -25,6 +26,10 @@ export class EntityCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: EntityCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: EntityCardConfig): void {
         assert(config, entityCardConfigStruct);

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -12,6 +12,7 @@ import "../../shared/editor/layout-picker";
 import "../../shared/form/mushroom-textfield";
 import { configElementStyle } from "../../utils/editor-styles";
 import { stateIcon } from "../../utils/icons/state-icon";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import { FanCardConfig, fanCardConfigStruct } from "./fan-card-config";
@@ -23,6 +24,10 @@ export class FanCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: FanCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: FanCardConfig): void {
         assert(config, fanCardConfigStruct);

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -12,6 +12,7 @@ import "../../shared/editor/layout-picker";
 import "../../shared/form/mushroom-textfield";
 import { configElementStyle } from "../../utils/editor-styles";
 import { stateIcon } from "../../utils/icons/state-icon";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
 import { LightCardConfig, lightCardConfigStruct } from "./light-card-config";
@@ -23,6 +24,10 @@ export class LightCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: LightCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: LightCardConfig): void {
         assert(config, lightCardConfigStruct);

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -12,6 +12,7 @@ import "../../shared/editor/layout-picker";
 import "../../shared/form/mushroom-textfield";
 import { configElementStyle } from "../../utils/editor-styles";
 import { stateIcon } from "../../utils/icons/state-icon";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { PERSON_CARD_EDITOR_NAME, PERSON_ENTITY_DOMAINS } from "./const";
 import { PersonCardConfig, personCardConfigStruct } from "./person-card-config";
@@ -23,6 +24,10 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: PersonCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: PersonCardConfig): void {
         assert(config, personCardConfigStruct);

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -11,6 +11,7 @@ import setupCustomlocalize from "../../localize";
 import "../../shared/editor/layout-picker";
 import "../../shared/form/mushroom-textarea";
 import { configElementStyle } from "../../utils/editor-styles";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { TEMPLATE_CARD_EDITOR_NAME } from "./const";
 import { TemplateCardConfig, templateCardConfigStruct } from "./template-card-config";
@@ -22,6 +23,10 @@ export class TemplateCardEditor extends LitElement implements LovelaceCardEditor
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: TemplateCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: TemplateCardConfig): void {
         assert(config, templateCardConfigStruct);

--- a/src/cards/title-card/title-card-editor.ts
+++ b/src/cards/title-card/title-card-editor.ts
@@ -5,6 +5,7 @@ import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import "../../shared/form/mushroom-textarea";
 import { configElementStyle } from "../../utils/editor-styles";
+import { loadHaComponents } from "../../utils/loader";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { TITLE_CARD_EDITOR_NAME } from "./const";
 import { TitleCardConfig, titleCardConfigStruct } from "./title-card-config";
@@ -14,6 +15,10 @@ export class TitleCardEditor extends LitElement implements LovelaceCardEditor {
     @property({ attribute: false }) public hass?: HomeAssistant;
 
     @state() private _config?: TitleCardConfig;
+
+    protected firstUpdated(): void {
+        void loadHaComponents();
+    }
 
     public setConfig(config: TitleCardConfig): void {
         assert(config, titleCardConfigStruct);

--- a/src/utils/loader.ts
+++ b/src/utils/loader.ts
@@ -1,0 +1,10 @@
+// Hack to load ha-components needed for editor
+export const loadHaComponents = () => {
+    if (
+        !customElements.get("hui-action-editor") ||
+        !customElements.get("ha-icon-picker") ||
+        !customElements.get("ha-entity-picker")
+    ) {
+        (customElements.get("hui-button-card") as any)?.getConfigElement();
+    }
+};


### PR DESCRIPTION
These components are not loader by default with 2022.3 version. 
This hack loads the components (temporary hack before an official HA solution) 