### PR TITLE
feat(slider): update percentage display when changing slider position

### DIFF
--- a/src/cards/cover-card/controls/cover-position-control.ts
+++ b/src/cards/cover-card/controls/cover-position-control.ts
@@ -12,14 +12,24 @@ export class CoverPositionControl extends LitElement {
 
     @property({ attribute: false }) public entity!: HassEntity;
 
-    private _onSliderChange(e: CustomEvent): void {
-        const value = Number((e.target as any).value);
-        if (isNaN(value)) return;
+    private onChange(e: CustomEvent<{ value: number }>): void {
+        const value = e.detail.value;
 
         this.hass.callService("cover", "set_cover_position", {
             entity_id: this.entity.entity_id,
             position: value,
         });
+    }
+
+    onCurrentChange(e: CustomEvent<{ value?: number }>): void {
+        const value = e.detail.value;
+        this.dispatchEvent(
+            new CustomEvent("current-change", {
+                detail: {
+                    value,
+                },
+            })
+        );
     }
 
     protected render(): TemplateResult {
@@ -30,7 +40,8 @@ export class CoverPositionControl extends LitElement {
                 .value=${position}
                 .disabled=${!isActive(this.entity)}
                 .showActive=${true}
-                @change=${this._onSliderChange}
+                @change=${this.onChange}
+                @current-change=${this.onCurrentChange}
             />
         `;
     }

--- a/src/cards/cover-card/utils.ts
+++ b/src/cards/cover-card/utils.ts
@@ -31,7 +31,7 @@ export const supportsSetTiltPosition = (entity: HassEntity) =>
 
 export function getPosition(entity: HassEntity) {
     return entity.attributes.current_position != null
-        ? (entity.attributes.current_position as number)
+        ? Math.round(entity.attributes.current_position)
         : undefined;
 }
 

--- a/src/cards/fan-card/controls/fan-percentage-control.ts
+++ b/src/cards/fan-card/controls/fan-percentage-control.ts
@@ -12,14 +12,23 @@ export class FanPercentageControl extends LitElement {
 
     @property({ attribute: false }) public entity!: HassEntity;
 
-    private _onSliderChange(e: CustomEvent): void {
-        const value = Number((e.target as any).value);
-        if (isNaN(value)) return;
-
+    onChange(e: CustomEvent<{ value: number }>): void {
+        const value = e.detail.value;
         this.hass.callService("fan", "set_percentage", {
             entity_id: this.entity.entity_id,
             percentage: value,
         });
+    }
+
+    onCurrentChange(e: CustomEvent<{ value?: number }>): void {
+        const value = e.detail.value;
+        this.dispatchEvent(
+            new CustomEvent("current-change", {
+                detail: {
+                    value,
+                },
+            })
+        );
     }
 
     protected render(): TemplateResult {
@@ -30,7 +39,8 @@ export class FanPercentageControl extends LitElement {
                 .value=${percentage}
                 .disabled=${!isActive(this.entity)}
                 .showActive=${true}
-                @change=${this._onSliderChange}
+                @change=${this.onChange}
+                @current-change=${this.onCurrentChange}
             />
         `;
     }

--- a/src/cards/light-card/controls/light-brightness-control.ts
+++ b/src/cards/light-card/controls/light-brightness-control.ts
@@ -11,14 +11,23 @@ export class LightBrighnessControl extends LitElement {
 
     @property({ attribute: false }) public entity!: HassEntity;
 
-    onChange(e: CustomEvent): void {
-        const value = Number((e.target as any).value);
-        if (isNaN(value)) return;
-
+    onChange(e: CustomEvent<{ value: number }>): void {
+        const value = e.detail.value;
         this.hass.callService("light", "turn_on", {
             entity_id: this.entity.entity_id,
             brightness_pct: value,
         });
+    }
+
+    onCurrentChange(e: CustomEvent<{ value?: number }>): void {
+        const value = e.detail.value;
+        this.dispatchEvent(
+            new CustomEvent("current-change", {
+                detail: {
+                    value,
+                },
+            })
+        );
     }
 
     protected render(): TemplateResult {
@@ -32,6 +41,7 @@ export class LightBrighnessControl extends LitElement {
                 .disabled=${state !== "on"}
                 .showActive=${true}
                 @change=${this.onChange}
+                @current-change=${this.onCurrentChange}
             />
         `;
     }

--- a/src/cards/light-card/controls/light-color-control.ts
+++ b/src/cards/light-card/controls/light-color-control.ts
@@ -33,9 +33,8 @@ export class LightColorControl extends LitElement {
         return color.hsv().hue() / 360;
     }
 
-    onChange(e: CustomEvent): void {
-        const value = Number((e.target as any).value);
-        if (isNaN(value)) return;
+    onChange(e: CustomEvent<{ value: number }>): void {
+        const value = e.detail.value;
         this._percent = value;
 
         const rgb_color = this._percentToRGB(value / 100);

--- a/src/cards/light-card/controls/light-color-temp-control.ts
+++ b/src/cards/light-card/controls/light-color-temp-control.ts
@@ -11,9 +11,8 @@ export class LightColorTempControl extends LitElement {
 
     @property({ attribute: false }) public entity!: HassEntity;
 
-    onChange(e: CustomEvent): void {
-        const value = Number((e.target as any).value);
-        if (isNaN(value)) return;
+    onChange(e: CustomEvent<{ value: number }>): void {
+        const value = e.detail.value;
 
         this.hass.callService("light", "turn_on", {
             entity_id: this.entity.entity_id,

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -98,17 +98,33 @@ export class LightCard extends LitElement implements LovelaceCard {
             },
             ...config,
         };
-        this.setControls();
+        this.updateControls();
+        this.updateBrightness();
     }
 
     protected updated(changedProperties: PropertyValues) {
         super.updated(changedProperties);
         if (this.hass && changedProperties.has("hass")) {
-            this.setControls();
+            this.updateControls();
+            this.updateBrightness();
         }
     }
 
-    setControls() {
+    @state()
+    private brightness?: number;
+
+    updateBrightness() {
+        this.brightness = undefined;
+        if (!this._config || !this.hass || !this._config.entity) return;
+
+        const entity_id = this._config.entity;
+        const entity = this.hass.states[entity_id];
+
+        if (!entity) return;
+        this.brightness = getBrightness(entity);
+    }
+
+    updateControls() {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
@@ -155,9 +171,7 @@ export class LightCard extends LitElement implements LovelaceCard {
 
         const stateDisplay = computeStateDisplay(this.hass.localize, entity, this.hass.locale);
 
-        const brightness = getBrightness(entity);
-
-        const stateValue = brightness != null ? `${brightness}%` : stateDisplay;
+        const stateValue = this.brightness != null ? `${this.brightness}%` : stateDisplay;
 
         const lightRgbColor = getRGBColor(entity);
         const iconStyle = {};
@@ -230,6 +244,12 @@ export class LightCard extends LitElement implements LovelaceCard {
         `;
     }
 
+    private onCurrentBrightnessChange(e: CustomEvent<{ value?: number }>): void {
+        if (e.detail.value != null) {
+            this.brightness = e.detail.value;
+        }
+    }
+
     private renderActiveControl(entity: HassEntity): TemplateResult | null {
         switch (this._activeControl) {
             case "brightness_control":
@@ -251,6 +271,7 @@ export class LightCard extends LitElement implements LovelaceCard {
                         .hass=${this.hass}
                         .entity=${entity}
                         style=${styleMap(sliderStyle)}
+                        @current-change=${this.onCurrentBrightnessChange}
                     />
                 `;
             case "color_temp_control":

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -124,6 +124,12 @@ export class LightCard extends LitElement implements LovelaceCard {
         this.brightness = getBrightness(entity);
     }
 
+    private onCurrentBrightnessChange(e: CustomEvent<{ value?: number }>): void {
+        if (e.detail.value != null) {
+            this.brightness = e.detail.value;
+        }
+    }
+
     updateControls() {
         if (!this._config || !this.hass || !this._config.entity) return;
 
@@ -242,12 +248,6 @@ export class LightCard extends LitElement implements LovelaceCard {
                 `
             )}
         `;
-    }
-
-    private onCurrentBrightnessChange(e: CustomEvent<{ value?: number }>): void {
-        if (e.detail.value != null) {
-            this.brightness = e.detail.value;
-        }
     }
 
     private renderActiveControl(entity: HassEntity): TemplateResult | null {

--- a/src/cards/light-card/utils.ts
+++ b/src/cards/light-card/utils.ts
@@ -1,6 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import Color from "color";
-import { HomeAssistant } from "custom-card-helpers";
 
 export function getBrightness(entity: HassEntity): number | undefined {
     return entity.attributes.brightness != null

--- a/src/shared/slider.ts
+++ b/src/shared/slider.ts
@@ -56,7 +56,7 @@ export class SliderItem extends LitElement {
     }
 
     @query("#slider")
-    slider;
+    private slider;
 
     setupListeners() {
         if (this.slider && !this._mc) {
@@ -78,10 +78,24 @@ export class SliderItem extends LitElement {
             this._mc.on("panmove", (e) => {
                 const percentage = getPercentageFromEvent(e);
                 this.value = this.percentageToValue(percentage);
+                this.dispatchEvent(
+                    new CustomEvent("current-change", {
+                        detail: {
+                            value: Math.round(this.value),
+                        },
+                    })
+                );
             });
             this._mc.on("panend", (e) => {
                 const percentage = getPercentageFromEvent(e);
                 this.value = this.percentageToValue(percentage);
+                this.dispatchEvent(
+                    new CustomEvent("current-change", {
+                        detail: {
+                            value: undefined,
+                        },
+                    })
+                );
                 this.dispatchEvent(
                     new CustomEvent("change", {
                         detail: {


### PR DESCRIPTION
https://user-images.githubusercontent.com/5878303/159140360-0c1d4df8-e825-4aa6-88b6-08797e59d4b1.mp4

- Update light brightness display when changing slider position
- Update cover position display when changing slider position
- Update fan percentage display when changing slider position
- Some refactoring (use `detail.value` instead of `target.value` when using slider events)
- Use rounded value for cover position

Fix #148 
Fix #197 