### PR TITLE
fix(chips): fix conditional-chip config error when removing a condition

### DIFF
--- a/src/cards/chips-card/chips/conditional-chip-editor.ts
+++ b/src/cards/chips-card/chips/conditional-chip-editor.ts
@@ -278,7 +278,7 @@ export class ConditionalChipEditor extends LitElement implements LovelaceChipEdi
             return;
         }
         const conditions = [...this._config.conditions];
-        if (target.configValue === "entity" && target.value === "") {
+        if (target.configValue === "entity" && !target.value) {
             conditions.splice(target.idx, 1);
         } else {
             const condition = { ...conditions[target.idx] };


### PR DESCRIPTION
Fixes an issue where the entity portion of the object was removed but the state was left behind