### PR TITLE
Support getting the isActive state of plant domain entities

### DIFF
--- a/src/utils/entity.ts
+++ b/src/utils/entity.ts
@@ -23,6 +23,8 @@ export function isActive(entity: HassEntity) {
             return state === "home";
         case "vacuum":
             return state !== "docked";
+        case "plant":
+            return state === "problem"
         default:
             return true;
     }


### PR DESCRIPTION
This allows to signal problems with plants on the chips cards using color.

![plant chips](https://user-images.githubusercontent.com/6029412/161982903-3d15ddd1-50fe-4fb3-87ad-3c8449c06e11.png)
