### PR TITLE
fix(shape-icon): use box-shadow instead of outline

### DIFF
--- a/src/shared/shape-icon.ts
+++ b/src/shared/shape-icon.ts
@@ -44,11 +44,11 @@ export class ShapeIcon extends LitElement {
                 align-items: center;
                 justify-content: center;
                 background-color: var(--shape-color);
-                transition-property: background-color, outline;
+                transition-property: background-color, box-shadow;
                 transition-duration: 280ms;
                 transition-timing-function: ease-out;
                 animation: var(--shape-animation);
-                outline: var(--shape-outline-color) solid var(--shape-outline-size);
+                box-shadow: 0 0 0 var(--shape-outline-size) var(--shape-outline-color);
             }
             .shape ha-icon {
                 display: flex;


### PR DESCRIPTION
Safari apparently doesn't support round outlines with border-radius.  This achieves the desired effect while still being round.

Closes #245 