### PR TITLE
Entity picture option to chip entity card

### DIFF
--- a/src/cards/chips-card/chips-card-editor.ts
+++ b/src/cards/chips-card/chips-card-editor.ts
@@ -52,6 +52,7 @@ const entityChipConfigStruct = object({
     content_info: optional(string()),
     icon: optional(string()),
     icon_color: optional(string()),
+    use_entity_picture: optional(boolean()),
     tap_action: optional(actionConfigStruct),
     hold_action: optional(actionConfigStruct),
     double_tap_action: optional(actionConfigStruct),

--- a/src/cards/chips-card/chips/entity-chip-editor.ts
+++ b/src/cards/chips-card/chips/entity-chip-editor.ts
@@ -29,6 +29,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
             { name: "icon_color", selector: { "mush-color": {} } },
         ],
     },
+    { name: "use_entity_picture", selector: { boolean: {} } },
     { name: "tap_action", selector: { "mush-action": {} } },
     { name: "hold_action", selector: { "mush-action": {} } },
     { name: "double_tap_action", selector: { "mush-action": {} } },

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -56,6 +56,9 @@ export class EntityChip extends LitElement implements LovelaceChip {
         const name = this._config.name || entity.attributes.friendly_name || "";
         const icon = this._config.icon || stateIcon(entity);
         const iconColor = this._config.icon_color;
+        const picture = this._config.use_entity_picture
+            ? entity.attributes.entity_picture
+            : undefined;
 
         const stateDisplay = computeStateDisplay(this.hass.localize, entity, this.hass.locale);
 
@@ -83,11 +86,22 @@ export class EntityChip extends LitElement implements LovelaceChip {
                     hasDoubleClick: hasAction(this._config.double_tap_action),
                 })}
             >
-                <ha-icon
-                    .icon=${icon}
-                    style=${styleMap(iconStyle)}
-                    class=${classMap({ active })}
-                ></ha-icon>
+                ${ picture ?
+                    html`
+                        <img 
+                            src="${picture}"
+                            class="mushroom-chip-entity-picture"
+                        />
+                    `
+                    :
+                    html`
+                        <ha-icon
+                            .icon=${icon}
+                            style=${styleMap(iconStyle)}
+                            class=${classMap({ active })}
+                        ></ha-icon>
+                    `
+                }
                 ${content ? html`<span>${content}</span>` : null}
             </mushroom-chip>
         `;
@@ -100,6 +114,12 @@ export class EntityChip extends LitElement implements LovelaceChip {
             }
             ha-icon.active {
                 color: var(--color);
+            }
+            .mushroom-chip-entity-picture {
+                border-radius: var(--chip-entity-picture-border-radius);
+                
+                height: var(--chip-entity-picture-size);
+                width: var(--chip-entity-picture-size);
             }
         `;
     }

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -117,7 +117,6 @@ export class EntityChip extends LitElement implements LovelaceChip {
             }
             .mushroom-chip-entity-picture {
                 border-radius: var(--chip-entity-picture-border-radius);
-                
                 height: var(--chip-entity-picture-size);
                 width: var(--chip-entity-picture-size);
             }

--- a/src/utils/card-styles.ts
+++ b/src/utils/card-styles.ts
@@ -29,6 +29,8 @@ export const cardStyle = css`
         --chip-font-size: var(--mush-chip-font-size, 1em);
         --chip-font-weight: var(--mush-chip-font-weight, bold);
         --chip-icon-size: var(--mush-chip-icon-size, 1.5em);
+        --chip-entity-picture-border-radius: var(--mush-chip-entity-picture-border-radius, 50%);
+        --chip-entity-picture-size: var(--mush-chip-entity-picture-size, 24px);
         /* Slider */
         --slider-threshold: var(--mush-slider-threshold);
     }

--- a/src/utils/lovelace/chip/types.ts
+++ b/src/utils/lovelace/chip/types.ts
@@ -41,6 +41,7 @@ export type EntityChipConfig = {
     content_info?: Info;
     icon?: string;
     icon_color?: string;
+    use_entity_picture?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
     double_tap_action?: ActionConfig;


### PR DESCRIPTION
Option to show the entity picture instead of icon in the chip entity card.

Increased image size to 24px instead of 1.5em that icons was. 1.5em image seemed to be very small.

Feel free to review and comment it.