### PR TITLE
Amend person card logic to allow for room presence

### DIFF
--- a/.hass_dev/views/person-view.yaml
+++ b/.hass_dev/views/person-view.yaml
@@ -66,6 +66,15 @@ cards:
             dev_id: demo_anne_therese
             location_name: unknown
       - type: button
+        name: Living Room
+        icon: mdi:sofa
+        tap_action:
+          action: call-service
+          service: device_tracker.see
+          service_data:
+            dev_id: demo_anne_therese
+            location_name: Living Room
+      - type: button
         name: Office
         icon: mdi:office-building
         tap_action:

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -5,14 +5,18 @@ export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "mdi:help";
+    } else if(state === "not_home") {
+        return "mdi:home-export-outline"
     } else if (state === "home") {
         return "mdi:home";
     }
+
     const zone = zones.find((z) => state === z.attributes.friendly_name);
     if (zone && zone.attributes.icon) {
         return zone.attributes.icon;
     }
-    return "mdi:home-export-outline";
+
+    return "mdi:home";
 }
 
 export function getStateColor(entity: HassEntity, zones: HassEntity[]) {

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -23,6 +23,8 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "var(--rgb-state-person-unknown)";
+    } else if (state === "not_home"){
+        return "var(--rgb-state-person-not-home)";
     } else if (state === "home") {
         return "var(--rgb-state-person-home)";
     }
@@ -30,5 +32,5 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     if (isInZone) {
         return "var(--rgb-state-person-zone)";
     }
-    return "var(--rgb-state-person-not-home)";
+    return "var(--rgb-state-person-home)";
 }


### PR DESCRIPTION
Fixes https://github.com/piitaya/lovelace-mushroom/issues/348

I've adjusted the logic so that if the presence is "not_home", that is the only way the "not home"/`home-export-outline` badge icon can be shown.

It should then continue and check for zone icons, and will then default to the home icon. 
Should users like myself use custom device_trackers which combine home/away presence as well as room presence within the home, they will get the correct device badge icon

