### PR TITLE
Tiny Bugfix + Updated Italian translation

### DIFF
--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -1,5 +1,5 @@
 import { HomeAssistant, LovelaceCard, LovelaceCardEditor } from "custom-card-helpers";
-import { UnsubscribeFunc } from "home-assistant-js-websocket";
+import { Connection, UnsubscribeFunc } from "home-assistant-js-websocket";
 import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import "../../shared/shape-icon";

--- a/src/translations/it.json
+++ b/src/translations/it.json
@@ -87,6 +87,30 @@
             },
             "vacuum": {
                 "commands": "Comandi"
+            },
+            "media-player": {
+                "use_media_info": "Mostra le Informazioni Sorgente",
+                "use_media_artwork": "Usa la copertina della Sorgente",
+                "media_controls": "Controlli Media",
+                "media_controls_list": {
+                    "on_off": "Accendi/Spegni",
+                    "shuffle": "Riproduzione Casuale",
+                    "previous": "Traccia Precedente",
+                    "play_pause_stop": "Play/Pausa/Stop",
+                    "next": "Traccia Successiva",
+                    "repeat": "Loop"
+                },
+                "volume_controls": "Controlli del Volume",
+                "volume_controls_list": {
+                    "volume_buttons": "Bottoni del Volume",
+                    "volume_set": "Livello del Volume",
+                    "volume_mute": "Silenzia"
+                }
+            },
+            "lock": {
+                "lock": "Blocca",
+                "unlock": "Sblocca",
+                "open": "Aperto"
             }
         },
         "chip": {

--- a/src/utils/icons/cover-icon.ts
+++ b/src/utils/icons/cover-icon.ts
@@ -1,4 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
+import { state } from "lit/decorators";
 
 export const coverIcon = (state?: string, entity?: HassEntity): string => {
     const open = state !== "closed";
@@ -91,6 +92,7 @@ export const coverIcon = (state?: string, entity?: HassEntity): string => {
 export const computeOpenIcon = (stateObj: HassEntity): string => {
     switch (stateObj.attributes.device_class) {
         case "awning":
+        case "curtain":
         case "door":
         case "gate":
             return "mdi:arrow-expand-horizontal";
@@ -100,8 +102,10 @@ export const computeOpenIcon = (stateObj: HassEntity): string => {
 };
 
 export const computeCloseIcon = (stateObj: HassEntity): string => {
+    console.log(stateObj.attributes);
     switch (stateObj.attributes.device_class) {
         case "awning":
+        case "curtain":
         case "door":
         case "gate":
             return "mdi:arrow-collapse-horizontal";

--- a/src/utils/icons/cover-icon.ts
+++ b/src/utils/icons/cover-icon.ts
@@ -101,7 +101,6 @@ export const computeOpenIcon = (stateObj: HassEntity): string => {
 };
 
 export const computeCloseIcon = (stateObj: HassEntity): string => {
-    console.log(stateObj.attributes);
     switch (stateObj.attributes.device_class) {
         case "awning":
         case "curtain":

--- a/src/utils/icons/cover-icon.ts
+++ b/src/utils/icons/cover-icon.ts
@@ -1,5 +1,4 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { state } from "lit/decorators";
 
 export const coverIcon = (state?: string, entity?: HassEntity): string => {
     const open = state !== "closed";


### PR DESCRIPTION
- Fix to issue #371 :
    Importing `Connection` in `title-card.ts`.
- Fix to issue #369  :
Displaying `mdi:arrow-collapse-horizontal` and `mdi:arrow-expand-horizontal` when the cover's device class is `curtain` as per HA's entity card. 