### PR TITLE
feat(fan): Fan direction

### DIFF
--- a/.hass_dev/views/fan-view.yaml
+++ b/.hass_dev/views/fan-view.yaml
@@ -28,6 +28,7 @@ cards:
         name: Multiple controls
         show_percentage_control: true
         show_oscillate_control: true
+        show_direction_control: true
     columns: 2
     square: false
   - type: vertical-stack

--- a/.hass_dev/views/person-view.yaml
+++ b/.hass_dev/views/person-view.yaml
@@ -66,6 +66,15 @@ cards:
             dev_id: demo_anne_therese
             location_name: unknown
       - type: button
+        name: Living Room
+        icon: mdi:sofa
+        tap_action:
+          action: call-service
+          service: device_tracker.see
+          service_data:
+            dev_id: demo_anne_therese
+            location_name: Living Room
+      - type: button
         name: Office
         icon: mdi:office-building
         tap_action:

--- a/src/cards/fan-card/controls/fan-direction-control.ts
+++ b/src/cards/fan-card/controls/fan-direction-control.ts
@@ -1,0 +1,45 @@
+import { HomeAssistant } from "custom-card-helpers";
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { isActive } from "../../../ha/data/entity";
+import "../../../shared/slider";
+
+@customElement("mushroom-fan-direction-control")
+export class FanPercentageControl extends LitElement {
+    @property({ attribute: false }) public hass!: HomeAssistant;
+
+    @property({ attribute: false }) public entity!: HassEntity;
+
+    private _onTap(e: MouseEvent): void {
+        e.stopPropagation();
+        const direction = this.entity.attributes.direction == "forward" ? "reverse" : "forward";
+
+        this.hass.callService("fan", "set_direction", {
+            entity_id: this.entity.entity_id,
+            direction: direction,
+        });
+    }
+
+    protected render(): TemplateResult {
+        const direction = this.entity.attributes.direction;
+        const active = isActive(this.entity);
+
+        return html`
+            <mushroom-button
+                slot="icon"
+                .icon=${direction === "forward" ? "mdi:reload" : "mdi:restore"}
+                @click=${this._onTap}
+                .disabled=${!active}
+            />
+        `;
+    }
+
+    static get styles(): CSSResultGroup {
+        return css`
+            :host {
+                display: flex;
+            }
+        `;
+    }
+}

--- a/src/cards/fan-card/controls/fan-direction-control.ts
+++ b/src/cards/fan-card/controls/fan-direction-control.ts
@@ -6,7 +6,7 @@ import { isActive } from "../../../ha/data/entity";
 import "../../../shared/slider";
 
 @customElement("mushroom-fan-direction-control")
-export class FanPercentageControl extends LitElement {
+export class FanDirectionControl extends LitElement {
     @property({ attribute: false }) public hass!: HomeAssistant;
 
     @property({ attribute: false }) public entity!: HassEntity;

--- a/src/cards/fan-card/fan-card-config.ts
+++ b/src/cards/fan-card/fan-card-config.ts
@@ -12,7 +12,8 @@ export interface FanCardConfig extends LovelaceCardConfig {
     hide_state?: boolean;
     icon_animation?: boolean;
     show_percentage_control?: boolean;
-    show_oscillate_control?: boolean;
+    show_direction_control?: boolean;
+    show_reverse_control?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
     double_tap_action?: ActionConfig;
@@ -29,6 +30,7 @@ export const fanCardConfigStruct = assign(
         hide_state: optional(boolean()),
         show_percentage_control: optional(boolean()),
         show_oscillate_control: optional(boolean()),
+        show_direction_control: optional(boolean()),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),
         double_tap_action: optional(actionConfigStruct),

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -12,7 +12,7 @@ import { loadHaComponents } from "../../utils/loader";
 import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import { FanCardConfig, fanCardConfigStruct } from "./fan-card-config";
 
-const FAN_FIELDS = ["icon_animation", "show_percentage_control", "show_oscillate_control"];
+const FAN_FIELDS = ["icon_animation", "show_percentage_control", "show_oscillate_control", "show_direction_control"];
 
 const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
     { name: "entity", selector: { entity: { domain: FAN_ENTITY_DOMAINS } } },
@@ -39,6 +39,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
         schema: [
             { name: "show_percentage_control", selector: { boolean: {} } },
             { name: "show_oscillate_control", selector: { boolean: {} } },
+            { name: "show_direction_control", selector: { boolean: {} } },
         ],
     },
     { name: "tap_action", selector: { "mush-action": {} } },

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -184,7 +184,7 @@ export class FanCard extends LitElement implements LovelaceCard {
                         .secondary=${!hideState && stateValue}
                     ></mushroom-state-info>
                 </mushroom-state-item>
-                ${this._config.show_percentage_control || this._config.show_oscillate_control
+                ${this._config.show_percentage_control || this._config.show_oscillate_control || this._config.show_direction_control
                     ? html`
                           <div class="actions" ?rtl=${rtl}>
                               ${this._config.show_percentage_control

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -27,6 +27,7 @@ import { getLayoutFromConfig } from "../../utils/layout";
 import { FAN_CARD_EDITOR_NAME, FAN_CARD_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import "./controls/fan-oscillate-control";
 import "./controls/fan-percentage-control";
+import "./controls/fan-direction-control";
 import { FanCardConfig } from "./fan-card-config";
 import { getPercentage } from "./utils";
 
@@ -123,6 +124,7 @@ export class FanCard extends LitElement implements LovelaceCard {
         const stateDisplay = computeStateDisplay(this.hass.localize, entity, this.hass.locale);
 
         const active = isActive(entity);
+        const direction = entity.attributes.direction;
 
         let iconStyle = {};
         const percentage = getPercentage(entity);
@@ -132,6 +134,11 @@ export class FanCard extends LitElement implements LovelaceCard {
                 iconStyle["--animation-duration"] = `${1 / speed}s`;
             } else {
                 iconStyle["--animation-duration"] = `1s`;
+            }
+            if (direction === "forward") {
+                iconStyle["--animation-direction"] = "spin"
+            } else {
+                iconStyle["--animation-direction"] = "spinReverse"
             }
         }
 
@@ -197,6 +204,14 @@ export class FanCard extends LitElement implements LovelaceCard {
                                         ></mushroom-fan-oscillate-control>
                                     `
                                   : null}
+                              ${this._config.show_direction_control
+                                  ? html`
+                                        <mushroom-fan-direction-control
+                                            .hass=${this.hass}
+                                            .entity=${entity}
+                                        ></mushroom-fan-direction-control>
+                                    `
+                                  : null}
                           </div>
                       `
                     : null}
@@ -216,7 +231,7 @@ export class FanCard extends LitElement implements LovelaceCard {
                     --shape-color: rgba(var(--rgb-state-fan), 0.2);
                 }
                 mushroom-shape-icon.spin {
-                    --icon-animation: var(--animation-duration) infinite linear spin;
+                    --icon-animation: var(--animation-duration) infinite linear var(--animation-direction);
                 }
                 mushroom-shape-icon ha-icon {
                     color: red !important;

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -5,14 +5,18 @@ export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "mdi:help";
+    } else if(state === "not_home") {
+        return "mdi:home-export-outline"
     } else if (state === "home") {
         return "mdi:home";
     }
+
     const zone = zones.find((z) => state === z.attributes.friendly_name);
     if (zone && zone.attributes.icon) {
         return zone.attributes.icon;
     }
-    return "mdi:home-export-outline";
+
+    return "mdi:home";
 }
 
 export function getStateColor(entity: HassEntity, zones: HassEntity[]) {

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -23,6 +23,8 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "var(--rgb-state-person-unknown)";
+    } else if (state === "not_home"){
+        return "var(--rgb-state-person-not-home)";
     } else if (state === "home") {
         return "var(--rgb-state-person-home)";
     }
@@ -30,5 +32,5 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     if (isInZone) {
         return "var(--rgb-state-person-zone)";
     }
-    return "var(--rgb-state-person-not-home)";
+    return "var(--rgb-state-person-home)";
 }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -55,7 +55,8 @@
             "fan": {
                 "icon_animation": "Animate icon when active?",
                 "show_percentage_control": "Percentage control?",
-                "show_oscillate_control": "Oscillate control?"
+                "show_oscillate_control": "Oscillate control?",
+                "show_direction_control": "Direction control?"
             },
             "cover": {
                 "show_buttons_control": "Control buttons?",

--- a/src/utils/entity-styles.ts
+++ b/src/utils/entity-styles.ts
@@ -19,6 +19,14 @@ const strAnimations = {
         to {
             transform: rotate(360deg);
         }
+    }`,
+    spinReverse: `@keyframes spinReverse {
+        from {
+            transform: rotate(0deg);
+        }
+        to {
+            transform: rotate(-360deg);
+        }
     }`
 };
 


### PR DESCRIPTION
## Description
Added fan direction control to the fan card.  Button changes icon direction depending on entity direction attribute. 
Added in a new `spinReverse` animation too, which reverses the direction of the fan icon animation if enabled

## Related Issue
https://github.com/piitaya/lovelace-mushroom/issues/354

## Motivation and Context
Adds additional and much needed feature to the fan element

## How Has This Been Tested
No real world testing, however have tested and checked the device state in the HA developer tools

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
