### PR TITLE
feat(light): add collapsible controls for light

### DIFF
--- a/docs/cards/light.md
+++ b/docs/cards/light.md
@@ -21,6 +21,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `show_brightness_control` | boolean | `false`     | Show a slider to control brightness                                       |
 | `show_color_temp_control` | boolean | `false`     | Show a slider to control temperature color                                |
 | `show_color_control`      | boolean | `false`     | Show a slider to control RGB color                                        |
+| `enable_collapse`         | boolean | `false`     | Show a slider to control RGB color                                        |
 | `use_light_color`         | boolean | `false`     | Colorize the icon and slider according light temperature or color         |
 | `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                                   |
 | `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                                  |

--- a/docs/cards/light.md
+++ b/docs/cards/light.md
@@ -21,7 +21,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `show_brightness_control` | boolean | `false`     | Show a slider to control brightness                                       |
 | `show_color_temp_control` | boolean | `false`     | Show a slider to control temperature color                                |
 | `show_color_control`      | boolean | `false`     | Show a slider to control RGB color                                        |
-| `enable_collapse`         | boolean | `false`     | Collapse controls when off                                                |
+| `collapse_controls`         | boolean | `false`     | Collapse controls when off                                              |
 | `use_light_color`         | boolean | `false`     | Colorize the icon and slider according light temperature or color         |
 | `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                                   |
 | `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                                  |

--- a/docs/cards/light.md
+++ b/docs/cards/light.md
@@ -21,7 +21,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `show_brightness_control` | boolean | `false`     | Show a slider to control brightness                                       |
 | `show_color_temp_control` | boolean | `false`     | Show a slider to control temperature color                                |
 | `show_color_control`      | boolean | `false`     | Show a slider to control RGB color                                        |
-| `enable_collapse`         | boolean | `false`     | Show a slider to control RGB color                                        |
+| `enable_collapse`         | boolean | `false`     | Collapse slider when off                                                  |
 | `use_light_color`         | boolean | `false`     | Colorize the icon and slider according light temperature or color         |
 | `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                                   |
 | `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                                  |

--- a/docs/cards/light.md
+++ b/docs/cards/light.md
@@ -21,7 +21,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `show_brightness_control` | boolean | `false`     | Show a slider to control brightness                                       |
 | `show_color_temp_control` | boolean | `false`     | Show a slider to control temperature color                                |
 | `show_color_control`      | boolean | `false`     | Show a slider to control RGB color                                        |
-| `enable_collapse`         | boolean | `false`     | Collapse slider when off                                                  |
+| `enable_collapse`         | boolean | `false`     | Collapse controls when off                                                |
 | `use_light_color`         | boolean | `false`     | Colorize the icon and slider according light temperature or color         |
 | `tap_action`              | action  | `toggle`    | Home assistant action to perform on tap                                   |
 | `hold_action`             | action  | `more-info` | Home assistant action to perform on hold                                  |

--- a/src/cards/light-card/light-card-config.ts
+++ b/src/cards/light-card/light-card-config.ts
@@ -13,6 +13,7 @@ export interface LightCardConfig extends LovelaceCardConfig {
     show_brightness_control?: boolean;
     show_color_temp_control?: boolean;
     show_color_control?: boolean;
+    enable_collapse?: boolean;
     use_light_color?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
@@ -30,6 +31,7 @@ export const lightCardConfigStruct = assign(
         show_brightness_control: optional(boolean()),
         show_color_temp_control: optional(boolean()),
         show_color_control: optional(boolean()),
+        enable_collapse: optional(boolean()),
         use_light_color: optional(boolean()),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),

--- a/src/cards/light-card/light-card-config.ts
+++ b/src/cards/light-card/light-card-config.ts
@@ -13,7 +13,7 @@ export interface LightCardConfig extends LovelaceCardConfig {
     show_brightness_control?: boolean;
     show_color_temp_control?: boolean;
     show_color_control?: boolean;
-    enable_collapse?: boolean;
+    collapse_controls?: boolean;
     use_light_color?: boolean;
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
@@ -31,7 +31,7 @@ export const lightCardConfigStruct = assign(
         show_brightness_control: optional(boolean()),
         show_color_temp_control: optional(boolean()),
         show_color_control: optional(boolean()),
-        enable_collapse: optional(boolean()),
+        collapse_controls: optional(boolean()),
         use_light_color: optional(boolean()),
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -17,7 +17,7 @@ export const LIGHT_FIELDS = [
     "use_light_color",
     "show_color_temp_control",
     "show_color_control",
-    "enable_collapse",
+    "collapse_controls",
 ];
 
 const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
@@ -44,7 +44,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
             { name: "show_brightness_control", selector: { boolean: {} } },
             { name: "show_color_temp_control", selector: { boolean: {} } },
             { name: "show_color_control", selector: { boolean: {} } },
-            { name: "enable_collapse", selector: { boolean: {} } },
+            { name: "collapse_controls", selector: { boolean: {} } },
         ],
     },
     { name: "tap_action", selector: { "mush-action": {} } },

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -17,6 +17,7 @@ export const LIGHT_FIELDS = [
     "use_light_color",
     "show_color_temp_control",
     "show_color_control",
+    "enable_collapse",
 ];
 
 const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
@@ -43,6 +44,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
             { name: "show_brightness_control", selector: { boolean: {} } },
             { name: "show_color_temp_control", selector: { boolean: {} } },
             { name: "show_color_control", selector: { boolean: {} } },
+            { name: "enable_collapse", selector: { boolean: {} } },
         ],
     },
     { name: "tap_action", selector: { "mush-action": {} } },

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -141,14 +141,16 @@ export class LightCard extends LitElement implements LovelaceCard {
         if (!entity) return;
 
         const controls: LightCardControl[] = [];
-        if (this._config.show_brightness_control && supportsBrightnessControl(entity)) {
-            controls.push("brightness_control");
-        }
-        if (this._config.show_color_temp_control && supportsColorTempControl(entity)) {
-            controls.push("color_temp_control");
-        }
-        if (this._config.show_color_control && supportsColorControl(entity)) {
-            controls.push("color_control");
+        if (!this._config.enable_collapse || entity.state == 'on'){
+            if (this._config.show_brightness_control && supportsBrightnessControl(entity)) {
+                controls.push("brightness_control");
+            }
+            if (this._config.show_color_temp_control && supportsColorTempControl(entity)) {
+                controls.push("color_temp_control");
+            }
+            if (this._config.show_color_control && supportsColorControl(entity)) {
+                controls.push("color_control");
+            }
         }
         this._controls = controls;
         const isActiveControlSupported = this._activeControl

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -199,61 +199,47 @@ export class LightCard extends LitElement implements LovelaceCard {
 
         const rtl = computeRTL(this.hass);
 
-        const content =  html`
-            <mushroom-state-item
-                ?rtl=${rtl}
-                .layout=${layout}
-                @action=${this._handleAction}
-                .actionHandler=${actionHandler({
-                    hasHold: hasAction(this._config.hold_action),
-                    hasDoubleClick: hasAction(this._config.double_tap_action),
-                })}
-            >
-                <mushroom-shape-icon
-                    slot="icon"
-                    .disabled=${!active}
-                    .icon=${icon}
-                    style=${styleMap(iconStyle)}
-                ></mushroom-shape-icon>
-                ${!isAvailable(entity)
+        return html`
+            <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                <mushroom-state-item
+                    ?rtl=${rtl}
+                    .layout=${layout}
+                    @action=${this._handleAction}
+                    .actionHandler=${actionHandler({
+                        hasHold: hasAction(this._config.hold_action),
+                        hasDoubleClick: hasAction(this._config.double_tap_action),
+                    })}
+                >
+                    <mushroom-shape-icon
+                        slot="icon"
+                        .disabled=${!active}
+                        .icon=${icon}
+                        style=${styleMap(iconStyle)}
+                    ></mushroom-shape-icon>
+                    ${!isAvailable(entity)
+                        ? html`
+                              <mushroom-badge-icon
+                                  class="unavailable"
+                                  slot="badge"
+                                  icon="mdi:help"
+                              ></mushroom-badge-icon>
+                          `
+                        : null}
+                    <mushroom-state-info
+                        slot="info"
+                        .primary=${name}
+                        .secondary=${!hideState && stateValue}
+                    ></mushroom-state-info>
+                </mushroom-state-item>
+                ${this._controls.length > 0
                     ? html`
-                            <mushroom-badge-icon
-                                class="unavailable"
-                                slot="badge"
-                                icon="mdi:help"
-                            ></mushroom-badge-icon>
-                        `
+                          <div class="actions" ?rtl=${rtl}>
+                              ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
+                          </div>
+                      `
                     : null}
-                <mushroom-state-info
-                    slot="info"
-                    .primary=${name}
-                    .secondary=${!hideState && stateValue}
-                ></mushroom-state-info>
-            </mushroom-state-item>
-            ${this._controls.length > 0
-                ? html`
-                        <div class="actions" ?rtl=${rtl}>
-                            ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
-                        </div>
-                    `
-                : null}
+            </mushroom-card>
         `;
-
-        if (this._config.enable_collapse){
-            return html`
-                <ha-card>
-                    <mushroom-card .layout=${layout} no-card-style ?rtl=${rtl}>
-                        ${content}
-                    </mushroom-card>
-                </ha-card>
-            `;
-        }
-        else{
-            return html`
-                <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                ${content}</mushroom-card>
-            `;
-        }
     }
 
     private renderOtherControls(): TemplateResult | null {

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -199,47 +199,61 @@ export class LightCard extends LitElement implements LovelaceCard {
 
         const rtl = computeRTL(this.hass);
 
-        return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    <mushroom-shape-icon
-                        slot="icon"
-                        .disabled=${!active}
-                        .icon=${icon}
-                        style=${styleMap(iconStyle)}
-                    ></mushroom-shape-icon>
-                    ${!isAvailable(entity)
-                        ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
-                          `
-                        : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${!hideState && stateValue}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${this._controls.length > 0
+        const content =  html`
+            <mushroom-state-item
+                ?rtl=${rtl}
+                .layout=${layout}
+                @action=${this._handleAction}
+                .actionHandler=${actionHandler({
+                    hasHold: hasAction(this._config.hold_action),
+                    hasDoubleClick: hasAction(this._config.double_tap_action),
+                })}
+            >
+                <mushroom-shape-icon
+                    slot="icon"
+                    .disabled=${!active}
+                    .icon=${icon}
+                    style=${styleMap(iconStyle)}
+                ></mushroom-shape-icon>
+                ${!isAvailable(entity)
                     ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
-                          </div>
-                      `
+                            <mushroom-badge-icon
+                                class="unavailable"
+                                slot="badge"
+                                icon="mdi:help"
+                            ></mushroom-badge-icon>
+                        `
                     : null}
-            </mushroom-card>
+                <mushroom-state-info
+                    slot="info"
+                    .primary=${name}
+                    .secondary=${!hideState && stateValue}
+                ></mushroom-state-info>
+            </mushroom-state-item>
+            ${this._controls.length > 0
+                ? html`
+                        <div class="actions" ?rtl=${rtl}>
+                            ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
+                        </div>
+                    `
+                : null}
         `;
+
+        if (this._config.enable_collapse){
+            return html`
+                <ha-card>
+                    <mushroom-card .layout=${layout} no-card-style ?rtl=${rtl}>
+                        ${content}
+                    </mushroom-card>
+                </ha-card>
+            `;
+        }
+        else{
+            return html`
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                ${content}</mushroom-card>
+            `;
+        }
     }
 
     private renderOtherControls(): TemplateResult | null {
@@ -298,6 +312,13 @@ export class LightCard extends LitElement implements LovelaceCard {
         return [
             cardStyle,
             css`
+                ha-card {
+                    box-sizing: border-box;
+                    padding: var(--spacing);
+                    display: flex;
+                    flex-direction: column;
+                    justify-content: center;
+                }
                 mushroom-state-item {
                     cursor: pointer;
                 }

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -141,7 +141,7 @@ export class LightCard extends LitElement implements LovelaceCard {
         if (!entity) return;
 
         const controls: LightCardControl[] = [];
-        if (!this._config.enable_collapse || entity.state == 'on'){
+        if (!this._config.collapse_controls || entity.state == 'on'){
             if (this._config.show_brightness_control && supportsBrightnessControl(entity)) {
                 controls.push("brightness_control");
             }

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -298,13 +298,6 @@ export class LightCard extends LitElement implements LovelaceCard {
         return [
             cardStyle,
             css`
-                ha-card {
-                    box-sizing: border-box;
-                    padding: var(--spacing);
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                }
                 mushroom-state-item {
                     cursor: pointer;
                 }

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -50,6 +50,7 @@
                 "use_light_color": "Farbsteuerung verwenden",
                 "show_color_temp_control": "Farbtemperatursteuerung?",
                 "show_color_control": "Farbsteuerung?",
+                "enable_collapse": "Schieberegler einklappen, wenn aus",
                 "incompatible_controls": "Einige Steuerelemente werden möglicherweise nicht angezeigt, wenn Ihr Licht diese Funktion nicht unterstützt."
             },
             "fan": {

--- a/src/translations/de.json
+++ b/src/translations/de.json
@@ -50,7 +50,7 @@
                 "use_light_color": "Farbsteuerung verwenden",
                 "show_color_temp_control": "Farbtemperatursteuerung?",
                 "show_color_control": "Farbsteuerung?",
-                "enable_collapse": "Schieberegler einklappen, wenn aus",
+                "collapse_controls": "Schieberegler einklappen, wenn aus",
                 "incompatible_controls": "Einige Steuerelemente werden möglicherweise nicht angezeigt, wenn Ihr Licht diese Funktion nicht unterstützt."
             },
             "fan": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -50,6 +50,7 @@
                 "use_light_color": "Use light color",
                 "show_color_temp_control": "Temperature color control?",
                 "show_color_control": "Color control?",
+                "enable_collapse": "Collapse slider when off",
                 "incompatible_controls": "Some controls may not be displayed if your light does not support the feature."
             },
             "fan": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -50,7 +50,7 @@
                 "use_light_color": "Use light color",
                 "show_color_temp_control": "Temperature color control?",
                 "show_color_control": "Color control?",
-                "enable_collapse": "Collapse controls when off",
+                "collapse_controls": "Collapse controls when off",
                 "incompatible_controls": "Some controls may not be displayed if your light does not support the feature."
             },
             "fan": {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -50,7 +50,7 @@
                 "use_light_color": "Use light color",
                 "show_color_temp_control": "Temperature color control?",
                 "show_color_control": "Color control?",
-                "enable_collapse": "Collapse slider when off",
+                "enable_collapse": "Collapse controls when off",
                 "incompatible_controls": "Some controls may not be displayed if your light does not support the feature."
             },
             "fan": {


### PR DESCRIPTION
## Description
implementation of the "Collapse slider when off" function from [Ui Lovelace Minimalist](https://ui-lovelace-minimalist.github.io/UI/).

## Related Issue
[#126](https://github.com/piitaya/lovelace-mushroom/issues/126)

## Motivation and Context
I really liked the function & implemented a workaround with the state-switch card, but thought it would be great to have this function natively.

## How Has This Been Tested
I tested it with the Development server as mentioned in the README

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change locally.

I could need some help with translations, testing & documentation.
Also, I tried to align with the code style of this project, but I am open for critics.
