### PR TITLE
Added `start:hass-cmd` script for Windows CMD users

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ You can run a demo instance of Home Assistant with docker by running:
 npm run start:hass
 ```
 
-Once it's done, go to home assitant instance [http://localhost:8123](http://localhost:8123) and start configuration.
+Once it's done, go to Home Assistant instance [http://localhost:8123](http://localhost:8123) and start configuration.
+
+
+#### Windows Users 
+If you are on Windows, either run the above command in Powershell, or use the below if using Command Prompt:
+```sh
+npm run start:hass-cmd
+```
 
 ### Development
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "rollup -c --watch",
     "build": "rollup -c",
     "format": "prettier --write .",
-    "start:hass": "docker run --rm -p8123:8123 -v ${PWD}/.hass_dev:/config homeassistant/home-assistant:beta"
+    "start:hass": "docker run --rm -p8123:8123 -v ${PWD}/.hass_dev:/config homeassistant/home-assistant:beta",
+    "start:hass-cmd": "docker run --rm -p8123:8123 -v  %cd%/.hass_dev:/config homeassistant/home-assistant:beta"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Windows users that are using CMD rather than Powershell are unable to use the current `start:hass` script due to `PWD` not working correctly in CMD

I have added a `start:hass-cmd` script that uses `%cd%` rather than `PWD`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
Fixes https://github.com/piitaya/lovelace-mushroom/issues/398

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows development on Windows using CMD

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran the script in CMD

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change locally.
