### PR TITLE
feat(theme): add disabled color in theme and color selector

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LocalizeFunc, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LocalizeFunc, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { Action } from "../../utils/form/custom/ha-selector-mushroom-action";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
@@ -53,9 +54,7 @@ const computeSchema = memoizeOne((localize: LocalizeFunc, icon?: string): HaForm
 ]);
 
 @customElement(ALARM_CONTROl_PANEL_CARD_EDITOR_NAME)
-export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class SwitchCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: AlarmControlPanelCardConfig;
 
     connectedCallback() {
@@ -112,6 +111,6 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return [configElementStyle];
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -7,18 +7,20 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
-import { customElement, property, query, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { customElement, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { computeStateDisplay } from "../../ha/common/entity/compute-state-display";
+import { isAvailable } from "../../ha/data/entity";
 import "../../shared/badge-icon";
+import "../../shared/button";
+import "../../shared/button-group";
 import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
-import "../../shared/button";
-import "../../shared/button-group";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -39,7 +41,6 @@ import {
     isDisarmed,
     shouldPulse,
 } from "./utils";
-import { isAvailable } from "../../ha/data/entity";
 
 registerCustomCard({
     type: ALARM_CONTROl_PANEL_CARD_NAME,
@@ -62,7 +63,7 @@ const BUTTONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "clear"];
  */
 
 @customElement(ALARM_CONTROl_PANEL_CARD_NAME)
-export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
+export class AlarmControlPanelCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./alarm-control-panel-card-editor");
         return document.createElement(ALARM_CONTROl_PANEL_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -79,8 +80,6 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
             states: ["armed_home", "armed_away"],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: AlarmControlPanelCardConfig;
 
@@ -285,8 +284,8 @@ export class AlarmControlPanelCard extends LitElement implements LovelaceCard {
     }
 
     static get styles(): CSSResultGroup {
-        // Default colors are RGB values of HASS --label-badge-*
         return [
+            super.styles,
             cardStyle,
             css`
                 ha-card {

--- a/src/cards/chips-card/chips-card-chips-editor.ts
+++ b/src/cards/chips-card/chips-card-chips-editor.ts
@@ -9,6 +9,7 @@ import { CHIP_LIST, LovelaceChipConfig } from "../../utils/lovelace/chip/types";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
 import { sortableStyles } from "../../utils/sortable-styles";
 import "../../shared/form/mushroom-select";
+import { MushroomBaseElement } from "../../utils/base-element";
 
 let Sortable;
 
@@ -21,9 +22,7 @@ declare global {
 }
 
 @customElement("mushroom-chips-card-chips-editor")
-export class ChipsCardEditorChips extends LitElement {
-    @property({ attribute: false }) protected hass?: HomeAssistant;
-
+export class ChipsCardEditorChips extends MushroomBaseElement {
     @property({ attribute: false }) protected chips?: LovelaceChipConfig[];
 
     @property() protected label?: string;
@@ -268,6 +267,7 @@ export class ChipsCardEditorChips extends LitElement {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             sortableStyles,
             css`
                 .chip {

--- a/src/cards/chips-card/chips-card-editor.ts
+++ b/src/cards/chips-card/chips-card-editor.ts
@@ -1,6 +1,6 @@
-import { fireEvent, HASSDomEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, HASSDomEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import {
     any,
     array,
@@ -17,6 +17,7 @@ import {
 import setupCustomlocalize from "../../localize";
 import "../../shared/editor/alignment-picker";
 import { actionConfigStruct } from "../../utils/action-struct";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
 import { loadHaComponents } from "../../utils/loader";
 import { LovelaceChipConfig } from "../../utils/lovelace/chip/types";
@@ -143,9 +144,7 @@ const cardConfigStruct = assign(
 );
 
 @customElement(CHIPS_CARD_EDITOR_NAME)
-export class ChipsCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class ChipsCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: ChipsCardConfig;
 
     @state() private _subElementEditorConfig?: SubElementEditorConfig;

--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -5,16 +5,17 @@ import {
     LovelaceCardConfig,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { registerCustomCard } from "../../utils/custom-cards";
-import { CHIPS_CARD_EDITOR_NAME, CHIPS_CARD_NAME } from "./const";
 import "../../shared/chip";
-import { EntityChip } from "./chips";
-import "./chips";
-import { LovelaceChip, LovelaceChipConfig } from "../../utils/lovelace/chip/types";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
+import { registerCustomCard } from "../../utils/custom-cards";
 import { createChipElement } from "../../utils/lovelace/chip/chip-element";
+import { LovelaceChipConfig } from "../../utils/lovelace/chip/types";
+import "./chips";
+import { EntityChip } from "./chips";
+import { CHIPS_CARD_EDITOR_NAME, CHIPS_CARD_NAME } from "./const";
 
 export interface ChipsCardConfig extends LovelaceCardConfig {
     chips: LovelaceChipConfig[];
@@ -28,7 +29,7 @@ registerCustomCard({
 });
 
 @customElement(CHIPS_CARD_NAME)
-export class ChipsCard extends LitElement implements LovelaceCard {
+export class ChipsCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./chips-card-editor");
         return document.createElement(CHIPS_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -44,15 +45,6 @@ export class ChipsCard extends LitElement implements LovelaceCard {
 
     @state() private _config?: ChipsCardConfig;
 
-    private _hass?: HomeAssistant;
-
-    set hass(hass: HomeAssistant) {
-        this._hass = hass;
-        this.shadowRoot?.querySelectorAll("div > *").forEach((element: unknown) => {
-            (element as LovelaceChip).hass = hass;
-        });
-    }
-
     getCardSize(): number | Promise<number> {
         return 1;
     }
@@ -62,7 +54,7 @@ export class ChipsCard extends LitElement implements LovelaceCard {
     }
 
     protected render(): TemplateResult {
-        if (!this._config || !this._hass) {
+        if (!this._config || !this.hass) {
             return html``;
         }
 
@@ -71,7 +63,7 @@ export class ChipsCard extends LitElement implements LovelaceCard {
             alignment = `align-${this._config.alignment}`;
         }
 
-        const rtl = computeRTL(this._hass);
+        const rtl = computeRTL(this.hass);
 
         return html`
             <div class="chip-container ${alignment}" ?rtl=${rtl}>
@@ -85,14 +77,15 @@ export class ChipsCard extends LitElement implements LovelaceCard {
         if (!element) {
             return html``;
         }
-        if (this._hass) {
-            element.hass = this._hass;
+        if (this.hass) {
+            element.hass = this.hass;
         }
         return html`${element}`;
     }
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 .chip-container {

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
@@ -44,9 +45,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(COVER_CARD_EDITOR_NAME)
-export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class CoverCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: CoverCardConfig;
 
     connectedCallback() {
@@ -97,6 +96,6 @@ export class CoverCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return [configElementStyle];
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -8,8 +8,8 @@ import {
     LovelaceCardEditor,
 } from "custom-card-helpers";
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { computeStateDisplay } from "../../ha/common/entity/compute-state-display";
 import { CoverEntity } from "../../ha/data/cover";
 import { isActive, isAvailable } from "../../ha/data/entity";
@@ -19,6 +19,7 @@ import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -44,7 +45,7 @@ registerCustomCard({
 });
 
 @customElement(COVER_CARD_NAME)
-export class CoverCard extends LitElement implements LovelaceCard {
+export class CoverCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./cover-card-editor");
         return document.createElement(COVER_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -58,8 +59,6 @@ export class CoverCard extends LitElement implements LovelaceCard {
             entity: covers[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: CoverCardConfig;
 
@@ -242,6 +241,7 @@ export class CoverCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
@@ -46,9 +47,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(ENTITY_CARD_EDITOR_NAME)
-export class EntityCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class EntityCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: EntityCardConfig;
 
     connectedCallback() {
@@ -96,6 +95,6 @@ export class EntityCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -7,8 +7,8 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { computeStateDisplay } from "../../ha/common/entity/compute-state-display";
 import { isActive, isAvailable } from "../../ha/data/entity";
@@ -18,6 +18,7 @@ import "../../shared/shape-avatar";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
@@ -35,7 +36,7 @@ registerCustomCard({
 });
 
 @customElement(ENTITY_CARD_NAME)
-export class EntityCard extends LitElement implements LovelaceCard {
+export class EntityCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./entity-card-editor");
         return document.createElement(ENTITY_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -48,8 +49,6 @@ export class EntityCard extends LitElement implements LovelaceCard {
             entity: entities[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: EntityCardConfig;
 
@@ -173,6 +172,7 @@ export class EntityCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
@@ -47,9 +48,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(FAN_CARD_EDITOR_NAME)
-export class FanCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: FanCardConfig;
 
     connectedCallback() {
@@ -100,6 +99,6 @@ export class FanCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -7,7 +7,7 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -19,6 +19,7 @@ import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -37,7 +38,7 @@ registerCustomCard({
 });
 
 @customElement(FAN_CARD_NAME)
-export class FanCard extends LitElement implements LovelaceCard {
+export class FanCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./fan-card-editor");
         return document.createElement(FAN_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -51,8 +52,6 @@ export class FanCard extends LitElement implements LovelaceCard {
             entity: fans[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: FanCardConfig;
 
@@ -206,6 +205,7 @@ export class FanCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
@@ -51,9 +52,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(LIGHT_CARD_EDITOR_NAME)
-export class LightCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class LightCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: LightCardConfig;
 
     connectedCallback() {
@@ -104,6 +103,6 @@ export class LightCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return [configElementStyle];
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -7,8 +7,7 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { computeStateDisplay } from "../../ha/common/entity/compute-state-display";
@@ -20,6 +19,7 @@ import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -55,7 +55,7 @@ registerCustomCard({
 });
 
 @customElement(LIGHT_CARD_NAME)
-export class LightCard extends LitElement implements LovelaceCard {
+export class LightCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./light-card-editor");
         return document.createElement(LIGHT_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -69,8 +69,6 @@ export class LightCard extends LitElement implements LovelaceCard {
             entity: lights[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: LightCardConfig;
 
@@ -294,6 +292,7 @@ export class LightCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/lock-card/lock-card-editor.ts
+++ b/src/cards/lock-card/lock-card-editor.ts
@@ -5,6 +5,7 @@ import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import { LOCK_ENTITY_DOMAINS } from "../../ha/data/lock";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
@@ -31,9 +32,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(LOCK_CARD_EDITOR_NAME)
-export class LockCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class LockCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: LockCardConfig;
 
     connectedCallback() {
@@ -81,6 +80,6 @@ export class LockCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -8,25 +8,25 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
-import { isActive, isAvailable } from "../../ha/data/entity";
+import { isAvailable } from "../../ha/data/entity";
 import { LockEntity, LOCK_ENTITY_DOMAINS } from "../../ha/data/lock";
 import "../../shared/badge-icon";
 import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
-import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { getLayoutFromConfig } from "../../utils/layout";
 import { LOCK_CARD_EDITOR_NAME, LOCK_CARD_NAME } from "./const";
-import { LockCardConfig } from "./lock-card-config";
 import "./controls/lock-buttons-control";
+import { LockCardConfig } from "./lock-card-config";
 import { isActionPending, isLocked, isUnlocked } from "./utils";
 
 registerCustomCard({
@@ -36,7 +36,7 @@ registerCustomCard({
 });
 
 @customElement(LOCK_CARD_NAME)
-export class LockCard extends LitElement implements LovelaceCard {
+export class LockCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./lock-card-editor");
         return document.createElement(LOCK_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -50,8 +50,6 @@ export class LockCard extends LitElement implements LovelaceCard {
             entity: locks[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: LockCardConfig;
 
@@ -165,6 +163,7 @@ export class LockCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/media-player-card/media-player-card-editor.ts
+++ b/src/cards/media-player-card/media-player-card-editor.ts
@@ -16,6 +16,7 @@ import {
     MEDIA_LAYER_MEDIA_CONTROLS,
     MEDIA_PLAYER_VOLUME_CONTROLS,
 } from "./media-player-card-config";
+import { MushroomBaseElement } from "../../utils/base-element";
 
 export const MEDIA_FIELDS = [
     "use_media_info",
@@ -87,9 +88,7 @@ const computeSchema = memoizeOne((localize: LocalizeFunc, icon?: string): HaForm
 ]);
 
 @customElement(MEDIA_PLAYER_CARD_EDITOR_NAME)
-export class MediaCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class MediaCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: MediaPlayerCardConfig;
 
     connectedCallback() {
@@ -142,6 +141,6 @@ export class MediaCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return [configElementStyle];
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -31,6 +31,7 @@ import "../../shared/badge-icon";
 import "../../shared/card";
 import "../../shared/shape-avatar";
 import "../../shared/shape-icon";
+import { MushroomBaseElement } from "../../utils/base-element";
 
 type MediaPlayerCardControl = "media_control" | "volume_control";
 
@@ -46,7 +47,7 @@ registerCustomCard({
 });
 
 @customElement(MEDIA_PLAYER_CARD_NAME)
-export class MediaPlayerCard extends LitElement implements LovelaceCard {
+export class MediaPlayerCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./media-player-card-editor");
         return document.createElement(MEDIA_PLAYER_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -62,8 +63,6 @@ export class MediaPlayerCard extends LitElement implements LovelaceCard {
             entity: mediaPlayers[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: MediaPlayerCardConfig;
 
@@ -249,6 +248,7 @@ export class MediaPlayerCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { Action } from "../../utils/form/custom/ha-selector-mushroom-action";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
@@ -41,9 +42,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(PERSON_CARD_EDITOR_NAME)
-export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class SwitchCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: PersonCardConfig;
 
     connectedCallback() {
@@ -91,6 +90,6 @@ export class SwitchCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -8,14 +8,15 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { isActive, isAvailable } from "../../ha/data/entity";
 import "../../shared/badge-icon";
 import "../../shared/card";
 import "../../shared/shape-avatar";
 import "../../shared/shape-icon";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -32,7 +33,7 @@ registerCustomCard({
 });
 
 @customElement(PERSON_CARD_NAME)
-export class PersonCard extends LitElement implements LovelaceCard {
+export class PersonCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./person-card-editor");
         return document.createElement(PERSON_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -46,8 +47,6 @@ export class PersonCard extends LitElement implements LovelaceCard {
             entity: people[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: PersonCardConfig;
 
@@ -168,6 +167,7 @@ export class PersonCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -1,16 +1,17 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
+import { atLeastHaVersion } from "../../ha/util";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { loadHaComponents } from "../../utils/loader";
 import { TEMPLATE_CARD_EDITOR_NAME } from "./const";
 import { TemplateCardConfig, templateCardConfigStruct } from "./template-card-config";
-import { atLeastHaVersion } from "../../ha/util";
-import memoizeOne from "memoize-one";
 
 export const TEMPLATE_FIELDS = ["content", "primary", "secondary", "multiline_secondary"];
 
@@ -54,9 +55,7 @@ const computeSchema = memoizeOne((version: string): HaFormSchema[] => [
 ]);
 
 @customElement(TEMPLATE_CARD_EDITOR_NAME)
-export class TemplateCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class TemplateCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: TemplateCardConfig;
 
     connectedCallback() {
@@ -107,6 +106,6 @@ export class TemplateCardEditor extends LitElement implements LovelaceCardEditor
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -8,12 +8,13 @@ import {
     LovelaceCardEditor,
 } from "custom-card-helpers";
 import { Connection, UnsubscribeFunc } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
@@ -33,7 +34,7 @@ const TEMPLATE_KEYS = ["icon", "icon_color", "primary", "secondary"] as const;
 type TemplateKey = typeof TEMPLATE_KEYS[number];
 
 @customElement(TEMPLATE_CARD_NAME)
-export class TemplateCard extends LitElement implements LovelaceCard {
+export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./template-card-editor");
         return document.createElement(TEMPLATE_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -47,8 +48,6 @@ export class TemplateCard extends LitElement implements LovelaceCard {
             icon: "mdi:home",
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: TemplateCardConfig;
 
@@ -259,6 +258,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/title-card/title-card-editor.ts
+++ b/src/cards/title-card/title-card-editor.ts
@@ -1,8 +1,9 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { loadHaComponents } from "../../utils/loader";
@@ -18,9 +19,7 @@ const SCHEMA: HaFormSchema[] = [
 ];
 
 @customElement(TITLE_CARD_EDITOR_NAME)
-export class TitleCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class TitleCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: TitleCardConfig;
 
     connectedCallback() {
@@ -63,6 +62,6 @@ export class TitleCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -1,10 +1,11 @@
 import { HomeAssistant, LovelaceCard, LovelaceCardEditor } from "custom-card-helpers";
 import { Connection, UnsubscribeFunc } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { RenderTemplateResult, subscribeRenderTemplate } from "../../utils/ws-templates";
@@ -21,7 +22,7 @@ const TEMPLATE_KEYS = ["title", "subtitle"] as const;
 type TemplateKey = typeof TEMPLATE_KEYS[number];
 
 @customElement(TITLE_CARD_NAME)
-export class TitleCard extends LitElement implements LovelaceCard {
+export class TitleCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./title-card-editor");
         return document.createElement(TITLE_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -33,8 +34,6 @@ export class TitleCard extends LitElement implements LovelaceCard {
             title: "Hello, {{ user }} !",
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: TitleCardConfig;
 
@@ -184,6 +183,7 @@ export class TitleCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 .header {

--- a/src/cards/update-card/update-card-editor.ts
+++ b/src/cards/update-card/update-card-editor.ts
@@ -1,9 +1,10 @@
-import { fireEvent, HomeAssistant, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { Action } from "../../utils/form/custom/ha-selector-mushroom-action";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
@@ -44,9 +45,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
 ]);
 
 @customElement(UPDATE_CARD_EDITOR_NAME)
-export class UpdateCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class UpdateCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: UpdateCardConfig;
 
     connectedCallback() {
@@ -97,6 +96,6 @@ export class UpdateCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return [configElementStyle];
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -7,9 +7,8 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
 } from "custom-card-helpers";
-import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { computeStateDisplay } from "../../ha/common/entity/compute-state-display";
@@ -21,6 +20,7 @@ import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -38,7 +38,7 @@ registerCustomCard({
 });
 
 @customElement(UPDATE_CARD_NAME)
-export class UpdateCard extends LitElement implements LovelaceCard {
+export class UpdateCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./update-card-editor");
         return document.createElement(UPDATE_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -52,7 +52,6 @@ export class UpdateCard extends LitElement implements LovelaceCard {
             entity: updates[0],
         };
     }
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: UpdateCardConfig;
 
@@ -176,6 +175,7 @@ export class UpdateCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/cards/vacuum-card/vacuum-card-editor.ts
+++ b/src/cards/vacuum-card/vacuum-card-editor.ts
@@ -1,16 +1,17 @@
-import { fireEvent, HomeAssistant, LocalizeFunc, LovelaceCardEditor } from "custom-card-helpers";
-import { CSSResultGroup, html, LitElement, TemplateResult } from "lit";
-import { customElement, property, state } from "lit/decorators.js";
+import { fireEvent, LocalizeFunc, LovelaceCardEditor } from "custom-card-helpers";
+import { CSSResultGroup, html, TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { configElementStyle } from "../../utils/editor-styles";
 import { GENERIC_FIELDS } from "../../utils/form/fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { loadHaComponents } from "../../utils/loader";
 import { VACUUM_CARD_EDITOR_NAME, VACUUM_ENTITY_DOMAINS } from "./const";
-import { VACUUM_COMMANDS, VacuumCardConfig, vacuumCardConfigStruct } from "./vacuum-card-config";
+import { VacuumCardConfig, vacuumCardConfigStruct, VACUUM_COMMANDS } from "./vacuum-card-config";
 
 const VACUUM_FIELDS = ["commands"];
 
@@ -44,9 +45,7 @@ const computeSchema = memoizeOne((localize: LocalizeFunc, icon?: string): HaForm
 ]);
 
 @customElement(VACUUM_CARD_EDITOR_NAME)
-export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
-    @property({ attribute: false }) public hass?: HomeAssistant;
-
+export class VacuumCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: VacuumCardConfig;
 
     connectedCallback() {
@@ -97,6 +96,6 @@ export class VacuumCardEditor extends LitElement implements LovelaceCardEditor {
     }
 
     static get styles(): CSSResultGroup {
-        return configElementStyle;
+        return [super.styles, configElementStyle];
     }
 }

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -17,6 +17,7 @@ import "../../shared/card";
 import "../../shared/shape-icon";
 import "../../shared/state-info";
 import "../../shared/state-item";
+import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { actionHandler } from "../../utils/directives/action-handler-directive";
@@ -34,7 +35,7 @@ registerCustomCard({
 });
 
 @customElement(VACUUM_CARD_NAME)
-export class VacuumCard extends LitElement implements LovelaceCard {
+export class VacuumCard extends MushroomBaseElement implements LovelaceCard {
     public static async getConfigElement(): Promise<LovelaceCardEditor> {
         await import("./vacuum-card-editor");
         return document.createElement(VACUUM_CARD_EDITOR_NAME) as LovelaceCardEditor;
@@ -48,8 +49,6 @@ export class VacuumCard extends LitElement implements LovelaceCard {
             entity: vacuums[0],
         };
     }
-
-    @property({ attribute: false }) public hass!: HomeAssistant;
 
     @state() private _config?: VacuumCardConfig;
 
@@ -147,6 +146,7 @@ export class VacuumCard extends LitElement implements LovelaceCard {
 
     static get styles(): CSSResultGroup {
         return [
+            super.styles,
             cardStyle,
             css`
                 mushroom-state-item {

--- a/src/shared/button.ts
+++ b/src/shared/button.ts
@@ -19,9 +19,9 @@ export class Button extends LitElement {
         return css`
             :host {
                 --icon-color: var(--primary-text-color);
-                --icon-color-disabled: var(--disabled-text-color);
+                --icon-color-disabled: rgb(var(--rgb-disabled));
                 --bg-color: rgba(var(--rgb-primary-text-color), 0.05);
-                --bg-color-disabled: rgba(var(--rgb-primary-text-color), 0.05);
+                --bg-color-disabled: rgba(var(--rgb-disabled), 0.2);
                 width: 42px;
                 height: 42px;
                 flex: none;

--- a/src/shared/shape-avatar.ts
+++ b/src/shared/shape-avatar.ts
@@ -18,9 +18,9 @@ export class ShapePicture extends LitElement {
         return css`
             :host {
                 --main-color: var(--primary-text-color);
-                --main-color-disabled: var(--disabled-text-color);
+                --icon-color-disabled: rgb(var(--rgb-disabled));
                 --shape-color: rgba(var(--rgb-primary-text-color), 0.05);
-                --shape-color-disabled: rgba(var(--rgb-primary-text-color), 0.05);
+                --shape-color-disabled: rgba(var(--rgb-disabled), 0.2);
                 flex: none;
             }
             .container {

--- a/src/shared/shape-icon.ts
+++ b/src/shared/shape-icon.ts
@@ -26,10 +26,10 @@ export class ShapeIcon extends LitElement {
         return css`
             :host {
                 --icon-color: var(--primary-text-color);
-                --icon-color-disabled: var(--disabled-text-color);
+                --icon-color-disabled: rgb(var(--rgb-disabled));
                 --icon-animation: none;
                 --shape-color: rgba(var(--rgb-primary-text-color), 0.05);
-                --shape-color-disabled: rgba(var(--rgb-primary-text-color), 0.05);
+                --shape-color-disabled: rgba(var(--rgb-disabled), 0.2);
                 --shape-animation: none;
                 --shape-outline-color: transparent;
                 --shape-outline-size: 1px;

--- a/src/shared/slider.ts
+++ b/src/shared/slider.ts
@@ -168,8 +168,8 @@ export class SliderItem extends LitElement {
                 --main-color: rgba(var(--rgb-secondary-text-color), 1);
                 --bg-gradient: none;
                 --bg-color: rgba(var(--rgb-secondary-text-color), 0.2);
-                --main-color-inactive: var(--disabled-text-color);
-                --bg-color-inactive: rgba(var(--rgb-primary-text-color), 0.05);
+                --main-color-inactive: rgb(var(--rgb-disabled));
+                --bg-color-inactive: rgba(var(--rgb-disabled), 0.2);
             }
             .container {
                 display: flex;

--- a/src/utils/base-element.ts
+++ b/src/utils/base-element.ts
@@ -1,0 +1,37 @@
+import { HomeAssistant } from "custom-card-helpers";
+import { css, CSSResultGroup, LitElement, PropertyValues } from "lit";
+import { property } from "lit/decorators.js";
+import "../shared/badge-icon";
+import "../shared/card";
+import "../shared/shape-avatar";
+import "../shared/shape-icon";
+import "../shared/state-info";
+import "../shared/state-item";
+import { defaultColorCss, defaultDarkColorCss } from "./colors";
+import { themeVariables, themeColorCss } from "./theme";
+
+export class MushroomBaseElement extends LitElement {
+    @property({ attribute: false }) public hass?: HomeAssistant;
+
+    protected updated(changedProps: PropertyValues): void {
+        if (changedProps.has("hass") && this.hass) {
+            const darkMode = (this.hass.themes as any).darkMode as boolean;
+            this.toggleAttribute("dark-mode", darkMode);
+        }
+    }
+
+    static get styles(): CSSResultGroup {
+        return css`
+            :host {
+                ${defaultColorCss}
+            }
+            :host([dark-mode]) {
+                ${defaultDarkColorCss}
+            }
+            :host {
+                ${themeColorCss}
+                ${themeVariables}
+            }
+        `;
+    }
+}

--- a/src/utils/base-element.ts
+++ b/src/utils/base-element.ts
@@ -10,13 +10,21 @@ import "../shared/state-item";
 import { defaultColorCss, defaultDarkColorCss } from "./colors";
 import { themeVariables, themeColorCss } from "./theme";
 
+function computeDarkMode(hass?: HomeAssistant): boolean {
+    if (!hass) return false;
+    return (hass.themes as any).darkMode as boolean;
+}
 export class MushroomBaseElement extends LitElement {
-    @property({ attribute: false }) public hass?: HomeAssistant;
+    @property({ attribute: false }) public hass!: HomeAssistant;
 
     protected updated(changedProps: PropertyValues): void {
+        super.updated(changedProps);
         if (changedProps.has("hass") && this.hass) {
-            const darkMode = (this.hass.themes as any).darkMode as boolean;
-            this.toggleAttribute("dark-mode", darkMode);
+            const currentDarkMode = computeDarkMode(changedProps.get("hass"));
+            const newDarkMode = computeDarkMode(this.hass);
+            if (currentDarkMode !== newDarkMode) {
+                this.toggleAttribute("dark-mode", newDarkMode);
+            }
         }
     }
 

--- a/src/utils/card-styles.ts
+++ b/src/utils/card-styles.ts
@@ -1,39 +1,6 @@
 import { css } from "lit";
-import { colorCss } from "./colors";
 
 export const cardStyle = css`
-    :host {
-        ${colorCss}
-        --spacing: var(--mush-spacing, 12px);
-        /* Title */
-        --title-padding: var(--mush-title-padding, 24px 12px 16px);
-        --title-spacing: var(--mush-title-spacing, 12px);
-        --title-font-size: var(--mush-title-font-size, 24px);
-        --title-font-weight: var(--mush-title-font-weight, normal);
-        --title-line-height: var(--mush-title-line-height, 1.2);
-        --subtitle-font-size: var(--mush-subtitle-font-size, 16px);
-        --subtitle-font-weight: var(--mush-subtitle-font-weight, normal);
-        --subtitle-line-height: var(--mush-subtitle-line-height, 1.2);
-        /* Card */
-        --icon-border-radius: var(--mush-icon-border-radius, 50%);
-        --control-border-radius: var(--mush-control-border-radius, 12px);
-        --card-primary-font-size: var(--mush-card-primary-font-size, 14px);
-        --card-secondary-font-size: var(--mush-card-secondary-font-size, 12px);
-        --card-primary-font-weight: var(--mush-card-primary-font-weight, bold);
-        --card-secondary-font-weight: var(--mush-card-secondary-font-weight, bolder);
-        /* Chips */
-        --chip-spacing: var(--mush-chip-spacing, 8px);
-        --chip-padding: var(--mush-chip-padding, 0 10px);
-        --chip-height: var(--mush-chip-height, 36px);
-        --chip-border-radius: var(--mush-chip-border-radius, 18px);
-        --chip-font-size: var(--mush-chip-font-size, 1em);
-        --chip-font-weight: var(--mush-chip-font-weight, bold);
-        --chip-icon-size: var(--mush-chip-icon-size, 1.5em);
-        --chip-avatar-padding: var(--mush-chip-avatar-padding, 0.3em);
-        --chip-avatar-border-radius: var(--mush-chip-avatar-border-radius, 50%);
-        /* Slider */
-        --slider-threshold: var(--mush-slider-threshold);
-    }
     .actions {
         display: flex;
         flex-direction: row;

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -2,6 +2,7 @@ import { css } from "lit";
 import * as Color from "color";
 
 export const COLORS = [
+    "disabled",
     "red",
     "pink",
     "purple",
@@ -49,8 +50,7 @@ function capitalizeFirstLetter(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
-export const colorCss = css`
-    /* DEFAULT */
+export const defaultColorCss = css`
     --default-red: 244, 67, 54;
     --default-pink: 233, 30, 99;
     --default-purple: 156, 39, 176;
@@ -72,64 +72,9 @@ export const colorCss = css`
     --default-blue-grey: 96, 125, 139;
     --default-black: 0, 0, 0;
     --default-white: 255, 255, 255;
+    --default-disabled: 189, 189, 189;
+`;
 
-    /* RGB */
-    /* Standard colors */
-    --rgb-red: var(--mush-rgb-red, var(--default-red));
-    --rgb-pink: var(--mush-rgb-pink, var(--default-pink));
-    --rgb-purple: var(--mush-rgb-purple, var(--default-purple));
-    --rgb-deep-purple: var(--mush-rgb-deep-purple, var(--default-deep-purple));
-    --rgb-indigo: var(--mush-rgb-indigo, var(--default-indigo));
-    --rgb-blue: var(--mush-rgb-blue, var(--default-blue));
-    --rgb-light-blue: var(--mush-rgb-light-blue, var(--default-light-blue));
-    --rgb-cyan: var(--mush-rgb-cyan, var(--default-cyan));
-    --rgb-teal: var(--mush-rgb-teal, var(--default-teal));
-    --rgb-green: var(--mush-rgb-green, var(--default-green));
-    --rgb-light-green: var(--mush-rgb-light-green, var(--default-light-green));
-    --rgb-lime: var(--mush-rgb-lime, var(--default-lime));
-    --rgb-yellow: var(--mush-rgb-yellow, var(--default-yellow));
-    --rgb-amber: var(--mush-rgb-amber, var(--default-amber));
-    --rgb-orange: var(--mush-rgb-orange, var(--default-orange));
-    --rgb-deep-orange: var(--mush-rgb-deep-orange, var(--default-deep-orange));
-    --rgb-brown: var(--mush-rgb-brown, var(--default-brown));
-    --rgb-grey: var(--mush-rgb-grey, var(--default-grey));
-    --rgb-blue-grey: var(--mush-rgb-blue-grey, var(--default-blue-grey));
-    --rgb-black: var(--mush-rgb-black, var(--default-black));
-    --rgb-white: var(--mush-rgb-white, var(--default-white));
-
-    /* Action colors */
-    --rgb-info: var(--mush-rgb-info, var(--rgb-blue));
-    --rgb-success: var(--mush-rgb-success, var(--rgb-green));
-    --rgb-warning: var(--mush-rgb-warning, var(--rgb-orange));
-    --rgb-danger: var(--mush-rgb-danger, var(--rgb-red));
-
-    /* State colors */
-    --rgb-state-cover: var(--mush-rgb-state-cover, var(--rgb-blue));
-    --rgb-state-vacuum: var(--mush-rgb-state-vacuum, var(--rgb-teal));
-    --rgb-state-fan: var(--mush-rgb-state-fan, var(--rgb-green));
-    --rgb-state-light: var(--mush-rgb-state-light, var(--rgb-orange));
-    --rgb-state-entity: var(--mush-rgb-state-entity, var(--rgb-blue));
-    --rgb-state-media-player: var(--mush-rgb-state-media-player, var(--rgb-indigo));
-    --rgb-state-lock: var(--mush-rgb-state-lock, var(--rgb-blue));
-
-    /* State alarm colors */
-    --rgb-state-alarm-disarmed: var(--mush-rgb-state-alarm-disarmed, var(--rgb-info));
-    --rgb-state-alarm-armed: var(--mush-rgb-state-alarm-armed, var(--rgb-success));
-    --rgb-state-alarm-triggered: var(--mush-rgb-state-alarm-triggered, var(--rgb-danger));
-
-    /* State person colors */
-    --rgb-state-person-home: var(--mush-rgb-state-person-home, var(--rgb-success));
-    --rgb-state-person-not-home: var(--mush-rgb-state-person-not-home, var(--rgb-danger));
-    --rgb-state-person-zone: var(--mush-rgb-state-person-zone, var(--rgb-info));
-    --rgb-state-person-unknown: var(--mush-rgb-state-person-unknown, var(--rgb-grey));
-
-    /* State update colors */
-    --rgb-state-update-on: var(--mush-rgb-state-update-on, var(--rgb-orange));
-    --rgb-state-update-off: var(--mush-rgb-update-off, var(--rgb-green));
-    --rgb-state-update-installing: var(--mush-rgb-update-installing, var(--rgb-blue));
-
-    /* State lock colors */
-    --rgb-state-lock-locked: var(--mush-rgb-state-lock-locked, var(--rgb-green));
-    --rgb-state-lock-unlocked: var(--mush-rgb-state-lock-unlocked, var(--rgb-red));
-    --rgb-state-lock-pending: var(--mush-rgb-state-lock-pending, var(--rgb-orange));
+export const defaultDarkColorCss = css`
+    --default-disabled: 111, 111, 111;
 `;

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -2,7 +2,6 @@ import { css } from "lit";
 import * as Color from "color";
 
 export const COLORS = [
-    "disabled",
     "red",
     "pink",
     "purple",
@@ -24,6 +23,7 @@ export const COLORS = [
     "blue-grey",
     "black",
     "white",
+    "disabled",
 ];
 
 export function computeRgbColor(color: string): string {

--- a/src/utils/editor-styles.ts
+++ b/src/utils/editor-styles.ts
@@ -1,11 +1,7 @@
 import { css } from "lit";
 import { any, object, string } from "superstruct";
-import { colorCss } from "./colors";
 
 export const configElementStyle = css`
-    :host {
-        ${colorCss}
-    }
     ha-switch {
         padding: 16px 6px;
     }

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,96 @@
+import { css } from "lit";
+
+export const themeVariables = css`
+    --spacing: var(--mush-spacing, 12px);
+    /* Title */
+    --title-padding: var(--mush-title-padding, 24px 12px 16px);
+    --title-spacing: var(--mush-title-spacing, 12px);
+    --title-font-size: var(--mush-title-font-size, 24px);
+    --title-font-weight: var(--mush-title-font-weight, normal);
+    --title-line-height: var(--mush-title-line-height, 1.2);
+    --subtitle-font-size: var(--mush-subtitle-font-size, 16px);
+    --subtitle-font-weight: var(--mush-subtitle-font-weight, normal);
+    --subtitle-line-height: var(--mush-subtitle-line-height, 1.2);
+    /* Card */
+    --icon-border-radius: var(--mush-icon-border-radius, 50%);
+    --control-border-radius: var(--mush-control-border-radius, 12px);
+    --card-primary-font-size: var(--mush-card-primary-font-size, 14px);
+    --card-secondary-font-size: var(--mush-card-secondary-font-size, 12px);
+    --card-primary-font-weight: var(--mush-card-primary-font-weight, bold);
+    --card-secondary-font-weight: var(--mush-card-secondary-font-weight, bolder);
+    /* Chips */
+    --chip-spacing: var(--mush-chip-spacing, 8px);
+    --chip-padding: var(--mush-chip-padding, 0 10px);
+    --chip-height: var(--mush-chip-height, 36px);
+    --chip-border-radius: var(--mush-chip-border-radius, 18px);
+    --chip-font-size: var(--mush-chip-font-size, 1em);
+    --chip-font-weight: var(--mush-chip-font-weight, bold);
+    --chip-icon-size: var(--mush-chip-icon-size, 1.5em);
+    --chip-avatar-padding: var(--mush-chip-avatar-padding, 0.3em);
+    --chip-avatar-border-radius: var(--mush-chip-avatar-border-radius, 50%);
+    /* Slider */
+    --slider-threshold: var(--mush-slider-threshold);
+`;
+
+export const themeColorCss = css`
+    /* RGB */
+    /* Standard colors */
+    --rgb-red: var(--mush-rgb-red, var(--default-red));
+    --rgb-pink: var(--mush-rgb-pink, var(--default-pink));
+    --rgb-purple: var(--mush-rgb-purple, var(--default-purple));
+    --rgb-deep-purple: var(--mush-rgb-deep-purple, var(--default-deep-purple));
+    --rgb-indigo: var(--mush-rgb-indigo, var(--default-indigo));
+    --rgb-blue: var(--mush-rgb-blue, var(--default-blue));
+    --rgb-light-blue: var(--mush-rgb-light-blue, var(--default-light-blue));
+    --rgb-cyan: var(--mush-rgb-cyan, var(--default-cyan));
+    --rgb-teal: var(--mush-rgb-teal, var(--default-teal));
+    --rgb-green: var(--mush-rgb-green, var(--default-green));
+    --rgb-light-green: var(--mush-rgb-light-green, var(--default-light-green));
+    --rgb-lime: var(--mush-rgb-lime, var(--default-lime));
+    --rgb-yellow: var(--mush-rgb-yellow, var(--default-yellow));
+    --rgb-amber: var(--mush-rgb-amber, var(--default-amber));
+    --rgb-orange: var(--mush-rgb-orange, var(--default-orange));
+    --rgb-deep-orange: var(--mush-rgb-deep-orange, var(--default-deep-orange));
+    --rgb-brown: var(--mush-rgb-brown, var(--default-brown));
+    --rgb-grey: var(--mush-rgb-grey, var(--default-grey));
+    --rgb-blue-grey: var(--mush-rgb-blue-grey, var(--default-blue-grey));
+    --rgb-black: var(--mush-rgb-black, var(--default-black));
+    --rgb-white: var(--mush-rgb-white, var(--default-white));
+    --rgb-disabled: var(--mush-rgb-disabled, var(--default-disabled));
+
+    /* Action colors */
+    --rgb-info: var(--mush-rgb-info, var(--rgb-blue));
+    --rgb-success: var(--mush-rgb-success, var(--rgb-green));
+    --rgb-warning: var(--mush-rgb-warning, var(--rgb-orange));
+    --rgb-danger: var(--mush-rgb-danger, var(--rgb-red));
+
+    /* State colors */
+    --rgb-state-cover: var(--mush-rgb-state-cover, var(--rgb-blue));
+    --rgb-state-vacuum: var(--mush-rgb-state-vacuum, var(--rgb-teal));
+    --rgb-state-fan: var(--mush-rgb-state-fan, var(--rgb-green));
+    --rgb-state-light: var(--mush-rgb-state-light, var(--rgb-orange));
+    --rgb-state-entity: var(--mush-rgb-state-entity, var(--rgb-blue));
+    --rgb-state-media-player: var(--mush-rgb-state-media-player, var(--rgb-indigo));
+    --rgb-state-lock: var(--mush-rgb-state-lock, var(--rgb-blue));
+
+    /* State alarm colors */
+    --rgb-state-alarm-disarmed: var(--mush-rgb-state-alarm-disarmed, var(--rgb-info));
+    --rgb-state-alarm-armed: var(--mush-rgb-state-alarm-armed, var(--rgb-success));
+    --rgb-state-alarm-triggered: var(--mush-rgb-state-alarm-triggered, var(--rgb-danger));
+
+    /* State person colors */
+    --rgb-state-person-home: var(--mush-rgb-state-person-home, var(--rgb-success));
+    --rgb-state-person-not-home: var(--mush-rgb-state-person-not-home, var(--rgb-danger));
+    --rgb-state-person-zone: var(--mush-rgb-state-person-zone, var(--rgb-info));
+    --rgb-state-person-unknown: var(--mush-rgb-state-person-unknown, var(--rgb-grey));
+
+    /* State update colors */
+    --rgb-state-update-on: var(--mush-rgb-state-update-on, var(--rgb-orange));
+    --rgb-state-update-off: var(--mush-rgb-update-off, var(--rgb-green));
+    --rgb-state-update-installing: var(--mush-rgb-update-installing, var(--rgb-blue));
+
+    /* State lock colors */
+    --rgb-state-lock-locked: var(--mush-rgb-state-lock-locked, var(--rgb-green));
+    --rgb-state-lock-unlocked: var(--mush-rgb-state-lock-unlocked, var(--rgb-red));
+    --rgb-state-lock-pending: var(--mush-rgb-state-lock-pending, var(--rgb-orange));
+`;


### PR DESCRIPTION
## Description
Add disabled color in theme, color selector and template. This PR allow `disabled` color usage like any other color.

![image](https://user-images.githubusercontent.com/5878303/165783625-ed194581-287c-4c00-a4be-5c8093243a28.png)

### Selector
![image](https://user-images.githubusercontent.com/5878303/165783106-c447a4c7-3ce3-4ec4-b831-1be22b06a88f.png)

### Template
```jinja2
{{ iif(is_state(entity, "on"), 'blue', "disabled") }}
```

### MushroomBaseElement
 All cards extends from `MushroomBaseElement` instead of `LitElement`. It is needed to support disabled color in dark mode. 

## Related Issue
No issues but requests on home assistant community

## Motivation and Context
Users want to have the same colors between template and entity.

## How Has This Been Tested
Test locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change locally.
