### PR TITLE
fix: vertical stack and ha-card

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -192,7 +192,7 @@ export class AlarmControlPanelCard extends MushroomBaseElement implements Lovela
 
         return html`
             <ha-card>
-                <mushroom-card .layout=${layout} no-card-style ?rtl=${rtl}>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
                     <mushroom-state-item
                         ?rtl=${rtl}
                         .layout=${layout}
@@ -288,14 +288,6 @@ export class AlarmControlPanelCard extends MushroomBaseElement implements Lovela
             super.styles,
             cardStyle,
             css`
-                ha-card {
-                    height: 100%;
-                    box-sizing: border-box;
-                    padding: var(--spacing);
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                }
                 mushroom-state-item {
                     cursor: pointer;
                 }

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -163,45 +163,47 @@ export class CoverCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    <mushroom-shape-icon
-                        slot="icon"
-                        .disabled=${!isActive(entity)}
-                        .icon=${icon}
-                    ></mushroom-shape-icon>
-                    ${!isAvailable(entity)
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                    >
+                        <mushroom-shape-icon
+                            slot="icon"
+                            .disabled=${!isActive(entity)}
+                            .icon=${icon}
+                        ></mushroom-shape-icon>
+                        ${!isAvailable(entity)
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${name}
+                            .secondary=${!hideState && stateValue}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    ${this._controls.length > 0
                         ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
+                              <div class="actions" ?rtl=${rtl}>
+                                  ${this.renderActiveControl(entity, layout)}
+                                  ${this.renderNextControlButton()}
+                              </div>
                           `
                         : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${!hideState && stateValue}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${this._controls.length > 0
-                    ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              ${this.renderActiveControl(entity, layout)}
-                              ${this.renderNextControlButton()}
-                          </div>
-                      `
-                    : null}
-            </mushroom-card>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -114,42 +114,44 @@ export class EntityCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                    .hide_info=${primary == null && secondary == null}
-                    .hide_icon=${hideIcon}
-                >
-                    ${picture
-                        ? html`
-                              <mushroom-shape-avatar
-                                  slot="icon"
-                                  .picture_url=${picture}
-                              ></mushroom-shape-avatar>
-                          `
-                        : this.renderIcon(icon, iconColor, isActive(entity))}
-                    ${!isAvailable(entity)
-                        ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
-                          `
-                        : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${primary}
-                        .secondary=${secondary}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-            </mushroom-card>
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                        .hide_info=${primary == null && secondary == null}
+                        .hide_icon=${hideIcon}
+                    >
+                        ${picture
+                            ? html`
+                                  <mushroom-shape-avatar
+                                      slot="icon"
+                                      .picture_url=${picture}
+                                  ></mushroom-shape-avatar>
+                              `
+                            : this.renderIcon(icon, iconColor, isActive(entity))}
+                        ${!isAvailable(entity)
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${primary}
+                            .secondary=${secondary}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -142,64 +142,66 @@ export class FanCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    <mushroom-shape-icon
-                        slot="icon"
-                        class=${classMap({
-                            spin: active && !!this._config.icon_animation,
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
-                        style=${styleMap(iconStyle)}
-                        .disabled=${!active}
-                        .icon=${icon}
-                    ></mushroom-shape-icon>
-                    ${!isAvailable(entity)
+                    >
+                        <mushroom-shape-icon
+                            slot="icon"
+                            class=${classMap({
+                                spin: active && !!this._config.icon_animation,
+                            })}
+                            style=${styleMap(iconStyle)}
+                            .disabled=${!active}
+                            .icon=${icon}
+                        ></mushroom-shape-icon>
+                        ${!isAvailable(entity)
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${name}
+                            .secondary=${!hideState && stateValue}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    ${this._config.show_percentage_control || this._config.show_oscillate_control
                         ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
+                              <div class="actions" ?rtl=${rtl}>
+                                  ${this._config.show_percentage_control
+                                      ? html`
+                                            <mushroom-fan-percentage-control
+                                                .hass=${this.hass}
+                                                .entity=${entity}
+                                                @current-change=${this.onCurrentPercentageChange}
+                                            ></mushroom-fan-percentage-control>
+                                        `
+                                      : null}
+                                  ${this._config.show_oscillate_control
+                                      ? html`
+                                            <mushroom-fan-oscillate-control
+                                                .hass=${this.hass}
+                                                .entity=${entity}
+                                            ></mushroom-fan-oscillate-control>
+                                        `
+                                      : null}
+                              </div>
                           `
                         : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${!hideState && stateValue}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${this._config.show_percentage_control || this._config.show_oscillate_control
-                    ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              ${this._config.show_percentage_control
-                                  ? html`
-                                        <mushroom-fan-percentage-control
-                                            .hass=${this.hass}
-                                            .entity=${entity}
-                                            @current-change=${this.onCurrentPercentageChange}
-                                        ></mushroom-fan-percentage-control>
-                                    `
-                                  : null}
-                              ${this._config.show_oscillate_control
-                                  ? html`
-                                        <mushroom-fan-oscillate-control
-                                            .hass=${this.hass}
-                                            .entity=${entity}
-                                        ></mushroom-fan-oscillate-control>
-                                    `
-                                  : null}
-                          </div>
-                      `
-                    : null}
-            </mushroom-card>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -139,7 +139,7 @@ export class LightCard extends MushroomBaseElement implements LovelaceCard {
         if (!entity) return;
 
         const controls: LightCardControl[] = [];
-        if (!this._config.collapse_controls || entity.state == 'on'){
+        if (!this._config.collapse_controls || entity.state == "on") {
             if (this._config.show_brightness_control && supportsBrightnessControl(entity)) {
                 controls.push("brightness_control");
             }
@@ -198,45 +198,47 @@ export class LightCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    <mushroom-shape-icon
-                        slot="icon"
-                        .disabled=${!active}
-                        .icon=${icon}
-                        style=${styleMap(iconStyle)}
-                    ></mushroom-shape-icon>
-                    ${!isAvailable(entity)
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                    >
+                        <mushroom-shape-icon
+                            slot="icon"
+                            .disabled=${!active}
+                            .icon=${icon}
+                            style=${styleMap(iconStyle)}
+                        ></mushroom-shape-icon>
+                        ${!isAvailable(entity)
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${name}
+                            .secondary=${!hideState && stateValue}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    ${this._controls.length > 0
                         ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
+                              <div class="actions" ?rtl=${rtl}>
+                                  ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
+                              </div>
                           `
                         : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${!hideState && stateValue}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${this._controls.length > 0
-                    ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
-                          </div>
-                      `
-                    : null}
-            </mushroom-card>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -96,41 +96,43 @@ export class LockCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    ${this.renderIcon(entity, icon, available)}
-                    ${!available
-                        ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
-                          `
-                        : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${!hideState && stateDisplay}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                <div class="actions" ?rtl=${rtl}>
-                    <mushroom-lock-buttons-control
-                        .hass=${this.hass}
-                        .entity=${entity}
-                        .fill=${layout !== "horizontal"}
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
                     >
-                    </mushroom-lock-buttons-control>
-                </div>
-            </mushroom-card>
+                        ${this.renderIcon(entity, icon, available)}
+                        ${!available
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${name}
+                            .secondary=${!hideState && stateDisplay}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    <div class="actions" ?rtl=${rtl}>
+                        <mushroom-lock-buttons-control
+                            .hass=${this.hass}
+                            .entity=${entity}
+                            .fill=${layout !== "horizontal"}
+                        >
+                        </mushroom-lock-buttons-control>
+                    </div>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -151,54 +151,56 @@ export class MediaPlayerCard extends MushroomBaseElement implements LovelaceCard
             : undefined;
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    ${artwork
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                    >
+                        ${artwork
+                            ? html`
+                                  <mushroom-shape-avatar
+                                      slot="icon"
+                                      .picture_url=${artwork}
+                                  ></mushroom-shape-avatar>
+                              `
+                            : html`
+                                  <mushroom-shape-icon
+                                      slot="icon"
+                                      .icon=${icon}
+                                      .disabled=${!isActive(entity)}
+                                  ></mushroom-shape-icon>
+                              `}
+                        ${entity.state === "unavailable"
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${nameDisplay}
+                            .secondary=${stateDisplay}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    ${this._controls.length > 0
                         ? html`
-                              <mushroom-shape-avatar
-                                  slot="icon"
-                                  .picture_url=${artwork}
-                              ></mushroom-shape-avatar>
-                          `
-                        : html`
-                              <mushroom-shape-icon
-                                  slot="icon"
-                                  .icon=${icon}
-                                  .disabled=${!isActive(entity)}
-                              ></mushroom-shape-icon>
-                          `}
-                    ${entity.state === "unavailable"
-                        ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
+                              <div class="actions" ?rtl=${rtl}>
+                                  ${this.renderActiveControl(entity, layout)}
+                                  ${this.renderOtherControls()}
+                              </div>
                           `
                         : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${nameDisplay}
-                        .secondary=${stateDisplay}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${this._controls.length > 0
-                    ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              ${this.renderActiveControl(entity, layout)}
-                              ${this.renderOtherControls()}
-                          </div>
-                      `
-                    : null}
-            </mushroom-card>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -103,43 +103,45 @@ export class PersonCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <div class="container">
-                    <mushroom-state-item
-                        ?rtl=${rtl}
-                        .layout=${layout}
-                        @action=${this._handleAction}
-                        .actionHandler=${actionHandler({
-                            hasHold: hasAction(this._config.hold_action),
-                            hasDoubleClick: hasAction(this._config.double_tap_action),
-                        })}
-                        hide_info=${hideName && hideState}
-                    >
-                        ${picture
-                            ? html`
-                                  <mushroom-shape-avatar
-                                      slot="icon"
-                                      .picture_url=${picture}
-                                  ></mushroom-shape-avatar>
-                              `
-                            : html`
-                                  <mushroom-shape-icon
-                                      slot="icon"
-                                      .icon=${icon}
-                                      .disabled=${!isActive(entity)}
-                                  ></mushroom-shape-icon>
-                              `}
-                        ${isAvailable(entity)
-                            ? this.renderStateBadge(stateIcon, stateColor)
-                            : this.renderUnavailableBadge()}
-                        <mushroom-state-info
-                            slot="info"
-                            .primary=${!hideName ? name : undefined}
-                            .secondary=${!hideState && stateDisplay}
-                        ></mushroom-state-info>
-                    </mushroom-state-item>
-                </div>
-            </mushroom-card>
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <div class="container">
+                        <mushroom-state-item
+                            ?rtl=${rtl}
+                            .layout=${layout}
+                            @action=${this._handleAction}
+                            .actionHandler=${actionHandler({
+                                hasHold: hasAction(this._config.hold_action),
+                                hasDoubleClick: hasAction(this._config.double_tap_action),
+                            })}
+                            hide_info=${hideName && hideState}
+                        >
+                            ${picture
+                                ? html`
+                                      <mushroom-shape-avatar
+                                          slot="icon"
+                                          .picture_url=${picture}
+                                      ></mushroom-shape-avatar>
+                                  `
+                                : html`
+                                      <mushroom-shape-icon
+                                          slot="icon"
+                                          .icon=${icon}
+                                          .disabled=${!isActive(entity)}
+                                      ></mushroom-shape-icon>
+                                  `}
+                            ${isAvailable(entity)
+                                ? this.renderStateBadge(stateIcon, stateColor)
+                                : this.renderUnavailableBadge()}
+                            <mushroom-state-info
+                                slot="info"
+                                .primary=${!hideName ? name : undefined}
+                                .secondary=${!hideState && stateDisplay}
+                            ></mushroom-state-info>
+                        </mushroom-state-item>
+                    </div>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -128,27 +128,29 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                    .hide_info=${!primary && !secondary}
-                    .hide_icon=${hideIcon}
-                >
-                    ${!hideIcon ? this.renderIcon(icon, iconColor) : undefined}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${primary}
-                        .secondary=${secondary}
-                        .multiline_secondary=${multiline_secondary}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-            </mushroom-card>
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                        .hide_info=${!primary && !secondary}
+                        .hide_icon=${hideIcon}
+                    >
+                        ${!hideIcon ? this.renderIcon(icon, iconColor) : undefined}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${primary}
+                            .secondary=${secondary}
+                            .multiline_secondary=${multiline_secondary}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -101,52 +101,54 @@ export class UpdateCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    ${picture
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                    >
+                        ${picture
+                            ? html`
+                                  <mushroom-shape-avatar
+                                      slot="icon"
+                                      .picture_url=${picture}
+                                  ></mushroom-shape-avatar>
+                              `
+                            : this.renderShapeIcon(entity, icon)}
+                        ${!isAvailable(entity)
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${name}
+                            .secondary=${stateValue}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    ${this._config.show_buttons_control &&
+                    supportsFeature(entity, UPDATE_SUPPORT_INSTALL)
                         ? html`
-                              <mushroom-shape-avatar
-                                  slot="icon"
-                                  .picture_url=${picture}
-                              ></mushroom-shape-avatar>
-                          `
-                        : this.renderShapeIcon(entity, icon)}
-                    ${!isAvailable(entity)
-                        ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
+                              <div class="actions" ?rtl=${rtl}>
+                                  <mushroom-update-buttons-control
+                                      .hass=${this.hass}
+                                      .entity=${entity}
+                                      .fill=${layout !== "horizontal"}
+                                  />
+                              </div>
                           `
                         : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${stateValue}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${this._config.show_buttons_control &&
-                supportsFeature(entity, UPDATE_SUPPORT_INSTALL)
-                    ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              <mushroom-update-buttons-control
-                                  .hass=${this.hass}
-                                  .entity=${entity}
-                                  .fill=${layout !== "horizontal"}
-                              />
-                          </div>
-                      `
-                    : null}
-            </mushroom-card>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -97,50 +97,52 @@ export class VacuumCard extends MushroomBaseElement implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         return html`
-            <mushroom-card .layout=${layout} ?rtl=${rtl}>
-                <mushroom-state-item
-                    ?rtl=${rtl}
-                    .layout=${layout}
-                    @action=${this._handleAction}
-                    .actionHandler=${actionHandler({
-                        hasHold: hasAction(this._config.hold_action),
-                        hasDoubleClick: hasAction(this._config.double_tap_action),
-                    })}
-                >
-                    <mushroom-shape-icon
-                        slot="icon"
-                        .disabled=${!active}
-                        .icon=${icon}
-                    ></mushroom-shape-icon>
-                    ${!isAvailable(entity)
+            <ha-card>
+                <mushroom-card .layout=${layout} ?rtl=${rtl}>
+                    <mushroom-state-item
+                        ?rtl=${rtl}
+                        .layout=${layout}
+                        @action=${this._handleAction}
+                        .actionHandler=${actionHandler({
+                            hasHold: hasAction(this._config.hold_action),
+                            hasDoubleClick: hasAction(this._config.double_tap_action),
+                        })}
+                    >
+                        <mushroom-shape-icon
+                            slot="icon"
+                            .disabled=${!active}
+                            .icon=${icon}
+                        ></mushroom-shape-icon>
+                        ${!isAvailable(entity)
+                            ? html`
+                                  <mushroom-badge-icon
+                                      class="unavailable"
+                                      slot="badge"
+                                      icon="mdi:help"
+                                  ></mushroom-badge-icon>
+                              `
+                            : null}
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${name}
+                            .secondary=${!hideState && stateValue}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                    ${isCommandsControlVisible(entity, commands)
                         ? html`
-                              <mushroom-badge-icon
-                                  class="unavailable"
-                                  slot="badge"
-                                  icon="mdi:help"
-                              ></mushroom-badge-icon>
+                              <div class="actions" ?rtl=${rtl}>
+                                  <mushroom-vacuum-commands-control
+                                      .hass=${this.hass}
+                                      .entity=${entity}
+                                      .commands=${commands}
+                                      .fill=${layout !== "horizontal"}
+                                  >
+                                  </mushroom-vacuum-commands-control>
+                              </div>
                           `
                         : null}
-                    <mushroom-state-info
-                        slot="info"
-                        .primary=${name}
-                        .secondary=${!hideState && stateValue}
-                    ></mushroom-state-info>
-                </mushroom-state-item>
-                ${isCommandsControlVisible(entity, commands)
-                    ? html`
-                          <div class="actions" ?rtl=${rtl}>
-                              <mushroom-vacuum-commands-control
-                                  .hass=${this.hass}
-                                  .entity=${entity}
-                                  .commands=${commands}
-                                  .fill=${layout !== "horizontal"}
-                              >
-                              </mushroom-vacuum-commands-control>
-                          </div>
-                      `
-                    : null}
-            </mushroom-card>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -5,15 +5,10 @@ import { Layout } from "../utils/layout";
 
 @customElement("mushroom-card")
 export class Card extends LitElement {
-    @property({ attribute: "no-card-style", type: Boolean }) public noCardStyle?: boolean;
-
     @property() public layout: Layout = "default";
 
     protected render(): TemplateResult {
-        if (this.noCardStyle) {
-            return this.renderContent();
-        }
-        return html`<ha-card>${this.renderContent()}</ha-card>`;
+        return this.renderContent();
     }
 
     renderContent() {
@@ -31,14 +26,6 @@ export class Card extends LitElement {
 
     static get styles(): CSSResultGroup {
         return css`
-            ha-card {
-                height: 100%;
-                box-sizing: border-box;
-                padding: var(--spacing);
-                display: flex;
-                flex-direction: column;
-                justify-content: center;
-            }
             .container {
                 display: flex;
                 flex-direction: column;

--- a/src/utils/card-styles.ts
+++ b/src/utils/card-styles.ts
@@ -1,6 +1,14 @@
 import { css } from "lit";
 
 export const cardStyle = css`
+    ha-card {
+        height: 100%;
+        box-sizing: border-box;
+        padding: var(--spacing);
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
     .actions {
         display: flex;
         flex-direction: row;


### PR DESCRIPTION
## Description
- `ha-card` node must be at the top just before the first shadow root element
- Fix incompatibility with `vertical-stack-card`

## Related Issue
#415

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
All cards tested one by one and with  `vertical-stack-card`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
