### PR TITLE
feat(theme): add theme variables option

### DIFF
--- a/src/cards/entity-card/entity-card-config.ts
+++ b/src/cards/entity-card/entity-card-config.ts
@@ -1,5 +1,5 @@
 import { ActionConfig, LovelaceCardConfig } from "custom-card-helpers";
-import { assign, boolean, enums, object, optional, string } from "superstruct";
+import { any, assign, boolean, enums, object, optional, string } from "superstruct";
 import { actionConfigStruct } from "../../utils/action-struct";
 import { baseLovelaceCardConfig } from "../../utils/editor-styles";
 import { Info, INFOS } from "../../utils/info";
@@ -19,6 +19,7 @@ export interface EntityCardConfig extends LovelaceCardConfig {
     tap_action?: ActionConfig;
     hold_action?: ActionConfig;
     double_tap_action?: ActionConfig;
+    theme_variables?: any;
 }
 
 export const entityCardConfigStruct = assign(
@@ -37,5 +38,6 @@ export const entityCardConfigStruct = assign(
         tap_action: optional(actionConfigStruct),
         hold_action: optional(actionConfigStruct),
         double_tap_action: optional(actionConfigStruct),
+        theme_variables: optional(any()),
     })
 );

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -5,7 +5,7 @@ import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
 import setupCustomlocalize from "../../localize";
 import { MushroomBaseElement } from "../../utils/base-element";
-import { GENERIC_LABELS } from "../../utils/form/generic-fields";
+import { GENERIC_HELPERS, GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { loadHaComponents } from "../../utils/loader";
@@ -44,6 +44,7 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
     { name: "tap_action", selector: { "mush-action": {} } },
     { name: "hold_action", selector: { "mush-action": {} } },
     { name: "double_tap_action", selector: { "mush-action": {} } },
+    { name: "theme_variables", selector: { object: {} } },
 ]);
 
 @customElement(ENTITY_CARD_EDITOR_NAME)
@@ -69,6 +70,15 @@ export class EntityCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
+    private _computeHelper = (schema: HaFormSchema) => {
+        const customLocalize = setupCustomlocalize(this.hass!);
+
+        if (GENERIC_HELPERS.includes(schema.name)) {
+            return customLocalize(`editor.card.generic.${schema.name}_helper`);
+        }
+        return "";
+    };
+
     protected render(): TemplateResult {
         if (!this.hass || !this._config) {
             return html``;
@@ -85,6 +95,7 @@ export class EntityCardEditor extends MushroomBaseElement implements LovelaceCar
                 .data=${this._config}
                 .schema=${schema}
                 .computeLabel=${this._computeLabel}
+                .computeHelper=${this._computeHelper}
                 @value-changed=${this._valueChanged}
             ></ha-form>
         `;

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -27,6 +27,7 @@ import { actionHandler } from "../../utils/directives/action-handler-directive";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { getInfo } from "../../utils/info";
 import { getLayoutFromConfig } from "../../utils/layout";
+import { computeThemeVariablesStyle } from "../../utils/theme";
 import { ENTITY_CARD_EDITOR_NAME, ENTITY_CARD_NAME } from "./const";
 import { EntityCardConfig } from "./entity-card-config";
 
@@ -110,9 +111,13 @@ export class EntityCard extends MushroomBaseElement implements LovelaceCard {
         const iconColor = this._config.icon_color;
 
         const rtl = computeRTL(this.hass);
+        const style = computeThemeVariablesStyle(this._config.theme_variables);
 
         return html`
-            <ha-card class=${classMap({ "fill-container": this._config.fill_container ?? false })}>
+            <ha-card
+                class=${classMap({ "fill-container": this._config.fill_container ?? false })}
+                style=${styleMap(style)}
+            >
                 <mushroom-card .layout=${layout} ?rtl=${rtl}>
                     <mushroom-state-item
                         ?rtl=${rtl}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -45,7 +45,9 @@
                 "secondary_info": "Secondary information",
                 "content_info": "Content",
                 "use_entity_picture": "Use entity picture?",
-                "collapsible_controls": "Collapse controls when off"
+                "collapsible_controls": "Collapse controls when off",
+                "theme_variables": "Theme variables",
+                "theme_variables_helper": "You can set all Mushroom theme variables here"
             },
             "light": {
                 "show_brightness_control": "Brightness control?",

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -45,7 +45,9 @@
                 "secondary_info": "Information secondaire",
                 "content_info": "Contenu",
                 "use_entity_picture": "Utiliser l'image de l'entité ?",
-                "collapsible_controls": "Reduire les contrôles quand éteint"
+                "collapsible_controls": "Reduire les contrôles quand éteint",
+                "theme_variables": "Variables du thème",
+                "theme_variables_helper": "Vous pouvez redéfinir toutes les variables du theme Mushroom ici"
             },
             "light": {
                 "show_brightness_control": "Contrôle de luminosité ?",

--- a/src/utils/form/generic-fields.ts
+++ b/src/utils/form/generic-fields.ts
@@ -10,4 +10,7 @@ export const GENERIC_LABELS = [
     "content_info",
     "use_entity_picture",
     "collapsible_controls",
+    "theme_variables",
 ];
+
+export const GENERIC_HELPERS = ["theme_variables"];


### PR DESCRIPTION
## Description
Allow theme override for each mushroom card.

TODO : add the option on all cards

```yaml
type: custom:mushroom-entity-card
entity: switch.decorative_lights
theme_variables:
  rgb-state-entity: var(--rgb-green)
  rgb-disabled: var(--rgb-red)
```

<img width="467" alt="image" src="https://user-images.githubusercontent.com/5878303/166122179-c9c0c23d-cd32-4a54-ab8c-583ecde5f50a.png">

Like others options, the option is available from UI
<img width="514" alt="image" src="https://user-images.githubusercontent.com/5878303/166122477-4febe0ac-4a5c-4eb5-b95b-5757928a5b6b.png">

## Related Issue
Nop

## Motivation and Context
Advanced users want to customize their card. For now, they use `card_mod`. This PR allow to override mushroom variables without using `card_mod` and from the UI.

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
