### PR TITLE
Add show_keypad to alarm card documentation

### DIFF
--- a/docs/cards/alarm.md
+++ b/docs/cards/alarm.md
@@ -20,6 +20,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `fill_container`    | boolean | `false`                        | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
 | `hide_state`        | boolean | `false`                        | Hide the entity state                                                               |
 | `states`            | list    | `["armed_home", "armed_away"]` | List of arm states to display                                                       |
+| `show_keypad`       | boolean | `false`                        | Show the keypad                                                                     |
 | `tap_action`        | action  | `more-info`                    | Home assistant action to perform on tap                                             |
 | `hold_action`       | action  | `more-info`                    | Home assistant action to perform on hold                                            |
 | `double_tap_action` | action  | `more-info`                    | Home assistant action to perform on double_tap                                      |


### PR DESCRIPTION
## Description
Update alarm card documentation according to #376
Documentation was not updated to add `show_keypad`

## Related Issue
#306

## Motivation and Context
Update the documentation
