### PR TITLE
Fix strict error handling in templates

### DIFF
--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -170,6 +170,7 @@ export class TemplateChip extends LitElement implements LovelaceChip {
                         user: this.hass.user!.name,
                         entity: this._config.entity,
                     },
+                    strict: true,
                 }
             );
             this._unsubRenderTemplates.set(key, sub);

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -211,6 +211,7 @@ export class TemplateCard extends LitElement implements LovelaceCard {
                         user: this.hass.user!.name,
                         entity: this._config.entity,
                     },
+                    strict: true,
                 }
             );
             this._unsubRenderTemplates.set(key, sub);

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -136,6 +136,7 @@ export class TitleCard extends LitElement implements LovelaceCard {
                         config: this._config,
                         user: this.hass.user!.name,
                     },
+                    strict: true,
                 }
             );
             this._unsubRenderTemplates.set(key, sub);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This fixes template rendering to let bubble up all template errors to the UI (instead of the Home Assistant logs), by marking the rendering as strict.

This prevents the Home Assistant logs to become, essentially, a keylogger; and also provides more feedback in the UI.

Reported and related to <https://github.com/home-assistant/core/issues/70259>

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

See above

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

With bare hands

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
