### PR TITLE
fix: missing ha-card

### DIFF
--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -105,8 +105,9 @@ export class ChipsCard extends LitElement implements LovelaceCard {
             cardStyle,
             css`
                 ha-card {
-                    background-color: transparent;
+                    background: none;
                     box-shadow: none;
+                    border-radius: 0;
                 }
                 .chip-container {
                     display: flex;

--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -7,7 +7,6 @@ import {
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { styleMap } from "lit/directives/style-map.js";
 import "../../shared/chip";
 import { computeDarkMode, MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";

--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -7,6 +7,7 @@ import {
 } from "custom-card-helpers";
 import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { styleMap } from "lit/directives/style-map.js";
 import "../../shared/chip";
 import { computeDarkMode, MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
@@ -80,9 +81,11 @@ export class ChipsCard extends LitElement implements LovelaceCard {
         const rtl = computeRTL(this._hass);
 
         return html`
-            <div class="chip-container ${alignment}" ?rtl=${rtl}>
-                ${this._config.chips.map((chip) => this.renderChip(chip))}
-            </div>
+            <ha-card>
+                <div class="chip-container ${alignment}" ?rtl=${rtl}>
+                    ${this._config.chips.map((chip) => this.renderChip(chip))}
+                </div>
+            </ha-card>
         `;
     }
 
@@ -102,6 +105,10 @@ export class ChipsCard extends LitElement implements LovelaceCard {
             MushroomBaseElement.styles,
             cardStyle,
             css`
+                ha-card {
+                    background-color: transparent;
+                    box-shadow: none;
+                }
                 .chip-container {
                     display: flex;
                     flex-direction: row;


### PR DESCRIPTION
## Description
Missing `ha-card` around chips

## Related Issue
N/A

## Motivation and Context
- Easy to customize with vertical-stack-in-card / stack-in-card and a better rendering

## How Has This Been Tested
- Locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.

## Before

![image](https://user-images.githubusercontent.com/958435/168309080-96873e0e-7da1-4662-88d7-cb87586745d0.png)

## After

![image](https://user-images.githubusercontent.com/958435/168308989-ee91fa01-eb55-4b3c-a486-cd69cad8a6ec.png)
