### PR TITLE
Revert "fix: missing ha-card"

### DIFF
--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -80,11 +80,9 @@ export class ChipsCard extends LitElement implements LovelaceCard {
         const rtl = computeRTL(this._hass);
 
         return html`
-            <ha-card>
-                <div class="chip-container ${alignment}" ?rtl=${rtl}>
-                    ${this._config.chips.map((chip) => this.renderChip(chip))}
-                </div>
-            </ha-card>
+            <div class="chip-container ${alignment}" ?rtl=${rtl}>
+                ${this._config.chips.map((chip) => this.renderChip(chip))}
+            </div>
         `;
     }
 
@@ -104,11 +102,6 @@ export class ChipsCard extends LitElement implements LovelaceCard {
             MushroomBaseElement.styles,
             cardStyle,
             css`
-                ha-card {
-                    background: none;
-                    box-shadow: none;
-                    border-radius: 0;
-                }
                 .chip-container {
                     display: flex;
                     flex-direction: row;


### PR DESCRIPTION
Reverts piitaya/lovelace-mushroom#482

@acesyde I'm not sure about this one because it adds additional padding.

# Before the PR
<img width="398" alt="Capture d’écran 2022-05-17 à 18 34 18" src="https://user-images.githubusercontent.com/5878303/168862808-44d9ac43-bed0-4e75-9a14-70ba6f20fee1.png">

# After the PR
<img width="410" alt="image" src="https://user-images.githubusercontent.com/5878303/168862726-714365d1-1cbf-447a-b1c5-abfd915a2bac.png">
