### PR TITLE
feat(chip): improve stack in card support

### DIFF
--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -80,9 +80,11 @@ export class ChipsCard extends LitElement implements LovelaceCard {
         const rtl = computeRTL(this._hass);
 
         return html`
-            <div class="chip-container ${alignment}" ?rtl=${rtl}>
-                ${this._config.chips.map((chip) => this.renderChip(chip))}
-            </div>
+            <ha-card>
+                <div class="chip-container ${alignment}" ?rtl=${rtl}>
+                    ${this._config.chips.map((chip) => this.renderChip(chip))}
+                </div>
+            </ha-card>
         `;
     }
 
@@ -100,8 +102,17 @@ export class ChipsCard extends LitElement implements LovelaceCard {
     static get styles(): CSSResultGroup {
         return [
             MushroomBaseElement.styles,
-            cardStyle,
             css`
+                ha-card {
+                    background: none;
+                    box-shadow: none;
+                    border-radius: 0;
+                }
+                :host-context(ha-card) {
+                    --ha-card-background: none;
+                    --ha-card-box-shadow: none;
+                    --chip-spacing: 0;
+                }
                 .chip-container {
                     display: flex;
                     flex-direction: row;

--- a/src/shared/chip.ts
+++ b/src/shared/chip.ts
@@ -2,7 +2,7 @@ import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
 import { property, customElement } from "lit/decorators.js";
 
 @customElement("mushroom-chip")
-export class BadgeIcon extends LitElement {
+export class Chip extends LitElement {
     @property() public icon: string = "";
 
     @property() public label: string = "";
@@ -13,7 +13,7 @@ export class BadgeIcon extends LitElement {
 
     protected render(): TemplateResult {
         return html`
-            <ha-card class="chip">
+            <div class="chip">
                 ${this.avatar ? html` <img class="avatar" src=${this.avatar} /> ` : null}
                 ${!this.avatarOnly
                     ? html`
@@ -22,7 +22,7 @@ export class BadgeIcon extends LitElement {
                           </div>
                       `
                     : null}
-            </ha-card>
+            </div>
         `;
     }
 
@@ -42,6 +42,13 @@ export class BadgeIcon extends LitElement {
                 display: flex;
                 flex-direction: row;
                 align-items: center;
+                box-shadow: var(
+                    --ha-card-box-shadow,
+                    0px 2px 1px -1px rgba(0, 0, 0, 0.2),
+                    0px 1px 1px 0px rgba(0, 0, 0, 0.14),
+                    0px 1px 3px 0px rgba(0, 0, 0, 0.12)
+                );
+                background: var(--ha-card-background, var(--card-background-color, white));
             }
             .avatar {
                 --avatar-size: calc(var(--chip-height) - 2 * var(--chip-avatar-padding));


### PR DESCRIPTION
## Description
Convert chip to standard ha-card. This improve support for card like `vertical-stack-in-card`.
Also, if chips-card are inside ha-card, border are removed to avoid card_mod usage.

## Example : 
<img width="240" alt="image" src="https://user-images.githubusercontent.com/5878303/168904621-f7303f68-8c22-42c0-9f4a-fd6e7f3366cf.png">

```yaml
type: custom:vertical-stack-in-card
cards:
  - type: custom:mushroom-light-card
    entity: light.bed_light
  - type: custom:mushroom-chips-card
    alignment: justify
    chips:
      - type: entity
        entity: sensor.outside_temperature
        icon_color: red
      - type: entity
        entity: sensor.iphone_de_paul_battery_level
        icon_color: grey
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the change locally.
