### PR TITLE
fix(chip): restore ha-card element on chip for better styling

### DIFF
--- a/src/shared/chip.ts
+++ b/src/shared/chip.ts
@@ -13,7 +13,7 @@ export class Chip extends LitElement {
 
     protected render(): TemplateResult {
         return html`
-            <div class="chip">
+            <ha-card>
                 ${this.avatar ? html` <img class="avatar" src=${this.avatar} /> ` : null}
                 ${!this.avatarOnly
                     ? html`
@@ -22,7 +22,7 @@ export class Chip extends LitElement {
                           </div>
                       `
                     : null}
-            </div>
+            </ha-card>
         `;
     }
 
@@ -32,7 +32,7 @@ export class Chip extends LitElement {
                 --icon-color: var(--primary-text-color);
                 --text-color: var(--primary-text-color);
             }
-            .chip {
+            ha-card {
                 box-sizing: border-box;
                 height: var(--chip-height);
                 min-width: var(--chip-height);


### PR DESCRIPTION
## Description
Restore ha-card on chip to allow style override for advanced users.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
