### PR TITLE
Add a "name & state" option for the content of the entity chips cards

### DIFF
--- a/docs/cards/entity.md
+++ b/docs/cards/entity.md
@@ -11,18 +11,18 @@ A entity card allow you to display an entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                 | Type                                                | Default     | Description                                                                         |
-| :------------------- | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
-| `entity`             | string                                              | Required    | Entity                                                                              |
-| `icon`               | string                                              | Optional    | Custom icon                                                                         |
-| `icon_color`         | string                                              | `blue`      | Custom color for icon when entity is state is active                                |
-| `hide_icon`          | boolean                                             | `false`     | Hide the entity icon                                                                |
-| `use_entity_picture` | boolean                                             | `false`     | Use the picture of the entity instead of icon                                       |
-| `name`               | string                                              | Optional    | Custom name                                                                         |
-| `layout`             | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
-| `fill_container`     | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
-| `primary_info`       | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                        |
-| `secondary_info`     | `name` `state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                                                      |
-| `tap_action`         | action                                              | `more-info` | Home assistant action to perform on tap                                             |
-| `hold_action`        | action                                              | `more-info` | Home assistant action to perform on hold                                            |
-| `double_tap_action`  | action                                              | `more-info` | Home assistant action to perform on double_tap                                      |
+| Name                 | Type                                                                 | Default     | Description                                                                         |
+| :------------------- |:---------------------------------------------------------------------| :---------- | :---------------------------------------------------------------------------------- |
+| `entity`             | string                                                               | Required    | Entity                                                                              |
+| `icon`               | string                                                               | Optional    | Custom icon                                                                         |
+| `icon_color`         | string                                                               | `blue`      | Custom color for icon when entity is state is active                                |
+| `hide_icon`          | boolean                                                              | `false`     | Hide the entity icon                                                                |
+| `use_entity_picture` | boolean                                                              | `false`     | Use the picture of the entity instead of icon                                       |
+| `name`               | string                                                               | Optional    | Custom name                                                                         |
+| `layout`             | string                                                               | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
+| `fill_container`     | boolean                                                              | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
+| `primary_info`       | `name` `state` `name-and-state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                        |
+| `secondary_info`     | `name` `state` `name-and-state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                                                      |
+| `tap_action`         | action                                                               | `more-info` | Home assistant action to perform on tap                                             |
+| `hold_action`        | action                                                               | `more-info` | Home assistant action to perform on hold                                            |
+| `double_tap_action`  | action                                                               | `more-info` | Home assistant action to perform on double_tap                                      |

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -11,6 +11,7 @@
                     "default": "Default information",
                     "name": "Name",
                     "state": "State",
+                    "name-and-state": "Name and state",
                     "last-changed": "Last Changed",
                     "last-updated": "Last Updated",
                     "none": "None"

--- a/src/translations/sv.json
+++ b/src/translations/sv.json
@@ -11,6 +11,7 @@
                     "default": "Förvald information",
                     "name": "Namn",
                     "state": "Status",
+                    "name-and-state": "Namn och status",
                     "last-changed": "Sist ändrad",
                     "last-updated": "Sist uppdaterad",
                     "none": "Ingen"

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -3,7 +3,7 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { html } from "lit";
 import { isAvailable, isUnknown } from "../ha/data/entity";
 
-export const INFOS = ["name", "state", "last-changed", "last-updated", "none"] as const;
+export const INFOS = ["name", "state", "name-and-state", "last-changed", "last-updated", "none"] as const;
 const TIMESTAMP_STATE_DOMAINS = ["button", "input_button", "scene"];
 
 export type Info = typeof INFOS[number];
@@ -15,27 +15,33 @@ export function getInfo(
     entity: HassEntity,
     hass: HomeAssistant
 ) {
-    switch (info) {
-        case "name":
-            return name;
-        case "state":
-            const domain = entity.entity_id.split(".")[0];
-            if (
-                (entity.attributes.device_class === "timestamp" ||
-                    TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
-                isAvailable(entity) &&
-                !isUnknown(entity)
-            ) {
-                return html`
+    function getState() {
+        const domain = entity.entity_id.split(".")[0];
+        if (
+            (entity.attributes.device_class === "timestamp" ||
+                TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
+            isAvailable(entity) &&
+            !isUnknown(entity)
+        ) {
+            return html`
                     <ha-relative-time
                         .hass=${hass}
                         .datetime=${entity.state}
                         capitalize
                     ></ha-relative-time>
                 `;
-            } else {
-                return state;
-            }
+        } else {
+            return state;
+        }
+    }
+
+    switch (info) {
+        case "name":
+            return name;
+        case "state":
+            return getState();
+        case "name-and-state":
+            return name + " " + getState();
         case "last-changed":
             return html`
                 <ha-relative-time


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a "name & state" option for the content of the entity chips cards according to enhancement request #303
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
#303
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally by adding an entity chip with the new state

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have tested the change locally.
