### PR TITLE
Weather entity state based icon

### DIFF
--- a/src/utils/icons/domain-icon.ts
+++ b/src/utils/icons/domain-icon.ts
@@ -48,7 +48,6 @@ const FIXED_DOMAIN_ICONS = {
     updater: "mdi:cloud-upload",
     vacuum: "mdi:robot-vacuum",
     water_heater: "mdi:thermometer",
-    weather: "mdi:weather-cloudy",
     zone: "mdi:map-marker-radius",
 };
 
@@ -112,6 +111,42 @@ export function domainIcon(domain: string, entity?: HassEntity, state?: string):
                     return state === "on" ? "mdi:toggle-switch" : "mdi:toggle-switch-off";
                 default:
                     return "mdi:flash";
+            }
+
+        case "weather":
+            switch (state) {
+                case "clear-night":
+                    return "mdi:weather-night";
+                case "cloudy":
+                    return "mdi:weather-cloudy";
+                case "exceptional":
+                    return "mdi:alert-circle-outline";
+                case "fog":
+                    return "mdi:weather-fog";
+                case "hail":
+                    return "mdi:weather-hail";
+                case "lightning":
+                    return "mdi:weather-lightning";
+                case "lightning-rainy":
+                    return "mdi:weather-lightning-rainy";
+                case "partlycloudy":
+                    return "mdi:weather-partly-cloudy";
+                case "pouring":
+                    return "mdi:weather-pouring";
+                case "rainy":
+                    return "mdi:weather-rainy";
+                case "snowy":
+                    return "mdi:weather-snowy";
+                case "snowy-rainy":
+                    return "mdi:weather-snowy-rainy";
+                case "sunny":
+                    return "mdi:weather-sunny";
+                case "windy":
+                    return "mdi:weather-windy";
+                case "windy-variant":
+                    return "mdi:weather-windy-variant";
+                default:
+                    return "mdi:weather-cloudy";
             }
 
         case "zwave":


### PR DESCRIPTION
I wanted to raise a feature request for this, but realized I could easily write the code for it.
I've used this as the source: https://github.com/spacegaier/frontend/blob/dev/src/data/weather.ts#L71-L86

## Description
Weather entity will have an icon matching with its state, like the standard HA entity cards.

## Related Issue
I didn't want to bother you with an issue with something I could implement myself.

## Motivation and Context
Making the cards better

## How Has This Been Tested
I haven't tested this

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the change locally.
