### PR TITLE
Prevent selecting values that don't lie on a step

### DIFF
--- a/src/shared/slider.ts
+++ b/src/shared/slider.ts
@@ -113,7 +113,8 @@ export class SliderItem extends LitElement {
                 if (this.disabled) return;
                 this.controlled = false;
                 const percentage = getPercentageFromEvent(e);
-                this.value = this.percentageToValue(percentage);
+                // Prevent from input releasing on a value that doesn't lie on a step
+                this.value = Math.round(this.percentageToValue(percentage) / this.step) * this.step;
                 this.dispatchEvent(
                     new CustomEvent("current-change", {
                         detail: {
@@ -124,7 +125,7 @@ export class SliderItem extends LitElement {
                 this.dispatchEvent(
                     new CustomEvent("change", {
                         detail: {
-                            value: Math.round(this.value / this.step) * this.step,
+                            value: this.value,
                         },
                     })
                 );
@@ -133,11 +134,12 @@ export class SliderItem extends LitElement {
             this._mc.on("singletap", (e) => {
                 if (this.disabled) return;
                 const percentage = getPercentageFromEvent(e);
-                this.value = this.percentageToValue(percentage);
+                // Prevent from input selecting a value that doesn't lie on a step
+                this.value = Math.round(this.percentageToValue(percentage) / this.step) * this.step;
                 this.dispatchEvent(
                     new CustomEvent("change", {
                         detail: {
-                            value: Math.round(this.value / this.step) * this.step,
+                            value: this.value,
                         },
                     })
                 );


### PR DESCRIPTION
## Description
This prevents from the input "settling" on a value that doesn't lie on a step.

## Related Issue
https://github.com/piitaya/lovelace-mushroom/issues/576

## Motivation and Context
In my opinion, I don't believe the slider should show a value that is not represented by the entity. Going from 33% to 40% doesn't speed up the fan -- the value of 33% is sent to Home Assistant both times.

This behavior is most visible on fans, and admittedly I don't have any other entities that I can test this with. But I assume the same expectation exists for all stepped entities (fans, covers, etc.)

## How Has This Been Tested
Given a fan with step size 33.3333:

1. Fan is initially off
2. User drags or tap position ~40%
3. Slider "snaps" to position 33% (fan is set to 33%, aka low) - *this is expected, existing behavior in mushroom*
4. User again drags or taps again to position ~40%, slider will not "snap back" to the 33% mark - *this PR aims to fix that behavior*

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have tested the change locally.
