### PR TITLE
fix(climate): button icon colors

### DIFF
--- a/src/shared/input-number.ts
+++ b/src/shared/input-number.ts
@@ -106,6 +106,8 @@ export class InputNumber extends LitElement {
             :host {
                 --text-color: var(--primary-text-color);
                 --text-color-disabled: rgb(var(--rgb-disabled));
+                --icon-color: var(--primary-text-color);
+                --icon-color-disabled: rgb(var(--rgb-disabled));
                 --bg-color: rgba(var(--rgb-primary-text-color), 0.05);
                 --bg-color-disabled: rgba(var(--rgb-disabled), 0.2);
                 height: var(--control-height);
@@ -144,6 +146,7 @@ export class InputNumber extends LitElement {
             .button ha-icon {
                 font-size: var(--control-height);
                 --mdc-icon-size: var(--control-icon-size);
+                color: var(--icon-color);
                 pointer-events: none;
             }
             span {


### PR DESCRIPTION
## Description
Add missing button icon color css

## Related Issue
closes #622 

## Motivation and Context
It's nice to be able to see the buttons based on the primary color text like the rest of the buttons

## How Has This Been Tested
Visually on my local test system

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
