### PR TITLE
Allow using 'source' for app icon

### DIFF
--- a/src/cards/media-player-card/utils.ts
+++ b/src/cards/media-player-card/utils.ts
@@ -64,29 +64,41 @@ export function getVolumeLevel(entity: MediaPlayerEntity) {
         : undefined;
 }
 
+const mediaIconMapping = {
+    app_name: {
+        spotify: "mdi:spotify",
+        "google podcasts": "mdi:google-podcast",
+        plex: "mdi:plex",
+        soundcloud: "mdi:soundcloud",
+        youtube: "mdi:youtube",
+        "oto music": "mdi:music-circle",
+        netflix: "mdi:netflix",
+    },
+    source: {
+        "google podcasts": "mdi:google-podcast",
+        "oto music": "mdi:music-circle",
+        netflix: "mdi:netflix",
+        ps5: "mdi:sony-playstation",
+        ps4: "mdi:sony-playstation",
+        playstation: "mdi:sony-playstation",
+        plex: "mdi:plex",
+        soundcloud: "mdi:soundcloud",
+        spotify: "mdi:spotify",
+        twitch: "mdi:twitch",
+        youtube: "mdi:youtube",
+    },
+};
+
 export function computeMediaIcon(config: MediaPlayerCardConfig, entity: MediaPlayerEntity): string {
     var icon = config.icon || stateIcon(entity);
 
     if (![UNAVAILABLE, UNKNOWN, OFF].includes(entity.state) && config.use_media_info) {
-        var app = entity.attributes.app_name?.toLowerCase();
-        switch (app) {
-            case "spotify":
-                return "mdi:spotify";
-            case "google podcasts":
-                return "mdi:google-podcast";
-            case "plex":
-                return "mdi:plex";
-            case "soundcloud":
-                return "mdi:soundcloud";
-            case "youtube":
-                return "mdi:youtube";
-            case "oto music":
-                return "mdi:music-circle";
-            case "netflix":
-                return "mdi:netflix";
-            default:
-                return icon;
-        }
+        Object.keys(mediaIconMapping).forEach((attribute) => {
+            var app = entity.attributes[attribute]?.toLowerCase();
+            if (app) {
+                icon = mediaIconMapping[attribute][app];
+            }
+        });
     }
     return icon;
 }


### PR DESCRIPTION
## Description
This PR allows integrations which use `source` rather than `app_name` to be given an app icon

<img width="412" alt="" src="https://user-images.githubusercontent.com/30210785/193654409-fed91992-09aa-4834-8cca-00acd2e32831.png">


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
Closes #758 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users may not want to use the full app picture but instead have an icon that fits in with the HA UI so they can use the icon. Some integrations didn't provide an `app_name` attribute for this, but instead uses `source`

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally using the instructions in README.md to develop against HA.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
