### PR TITLE
fix(fan): make fan percentage state behave like light brightness

### DIFF
--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -120,8 +120,8 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         const picture = computeEntityPicture(entity, appearance.icon_type);
 
         let stateDisplay = computeStateDisplay(this.hass.localize, entity, this.hass.locale);
-        if (this.percentage) {
-            stateDisplay += ` - ${this.percentage}%`;
+        if (this.percentage != null) {
+            stateDisplay = `${this.percentage}%`;
         }
 
         const rtl = computeRTL(this.hass);


### PR DESCRIPTION
## Description
This makes display state for fan speed percentage similar to that of light brightness.

Note the subtle differences between lights and fans:
https://github.com/piitaya/lovelace-mushroom/blob/829ece99388d5474fba895bd58cc2f3007217ac3/src/cards/light-card/light-card.ts#L177-L180
https://github.com/piitaya/lovelace-mushroom/blob/829ece99388d5474fba895bd58cc2f3007217ac3/src/cards/fan-card/fan-card.ts#L122-L125

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->
Fixes #765 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I have groups of fans and lights and right now, the fans stick out:
![image](https://user-images.githubusercontent.com/7625337/194967530-791b4965-1777-4982-b993-28baf3850484.png)

This PR makes fan speed percentage behave like light brightness:
![image](https://user-images.githubusercontent.com/7625337/194967657-23784b14-4b15-437c-a02a-03290dbb60c1.png)

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tested fans with and without support for fan speed percentage, in off and on states.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
> **Note**
> We'd need to update screenshots in the project README and the fan card docs. It's non-trivial for me to reproduce the screenshot in the project README.
- [X] I have tested the change locally.
