### PR TITLE
Button animation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
       "devDependencies": {
         "@babel/core": "^7.17.10",
         "@babel/preset-typescript": "^7.16.7",
-        "@material/mwc-ripple": "^0.25.3",
         "@material/tab-bar": "^14.0.0",
         "@rollup/plugin-babel": "^5.3.1",
         "@rollup/plugin-commonjs": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "devDependencies": {
     "@babel/core": "^7.17.10",
     "@babel/preset-typescript": "^7.16.7",
-    "@material/mwc-ripple": "^0.25.3",
     "@material/tab-bar": "^14.0.0",
     "@rollup/plugin-babel": "^5.3.1",
     "@rollup/plugin-commonjs": "^22.0.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,6 @@ import ignore from "./rollup-plugins/rollup-ignore-plugin.js";
 
 const IGNORED_FILES = [
     "@material/mwc-notched-outline/mwc-notched-outline.js",
-    "@material/mwc-ripple/mwc-ripple.js",
     "@material/mwc-list/mwc-list.js",
     "@material/mwc-list/mwc-list-item.js",
     "@material/mwc-menu/mwc-menu.js",


### PR DESCRIPTION
## Description
When press-holding a mushroom card, the UI shows a semi-transparent gray circle only once the `holdTime` has passed. The animation to show this circle also takes some milliseconds.
 
This behavior makes it very hard and slow for a user to understand when the press-hold is accepted by the UI.

This code changes the behavior from mwc-ripple to a custom animation that scales the button when being pressed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## Motivation and Context
This new behavior makes it more understandable for an end-user when the press-hold is accepted. Next to that, the UI feels more up-to-date.

The new behavior scales the button to a smaller version of the button (90%) and makes the holdTime 400ms instead of 500ms (+the time to animate the ripple element)

## How Has This Been Tested
The interaction has been tested manually by me using the development HA instance .

## Types of changes
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have tested the change locally.
