### PR TITLE
Fix ha card 2022.11

### DIFF
--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -106,6 +106,7 @@ export class ChipsCard extends LitElement implements LovelaceCard {
                     background: none;
                     box-shadow: none;
                     border-radius: 0;
+                    border: none;
                 }
                 .chip-container {
                     display: flex;

--- a/src/shared/chip.ts
+++ b/src/shared/chip.ts
@@ -42,8 +42,8 @@ export class Chip extends LitElement {
                 display: flex;
                 flex-direction: row;
                 align-items: center;
-                box-shadow: var(--chip-box-shadow);
                 background: var(--chip-background);
+                box-sizing: content-box;
             }
             .avatar {
                 --avatar-size: calc(var(--chip-height) - 2 * var(--chip-avatar-padding));

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -25,19 +25,12 @@ export const themeVariables = css`
     --chip-spacing: var(--mush-chip-spacing, 8px);
     --chip-padding: var(--mush-chip-padding, 0 0.25em);
     --chip-height: var(--mush-chip-height, 36px);
-    --chip-border-radius: var(--mush-chip-border-radius, 18px);
+    --chip-border-radius: var(--mush-chip-border-radius, 19px);
     --chip-font-size: var(--mush-chip-font-size, 0.3em);
     --chip-font-weight: var(--mush-chip-font-weight, bold);
     --chip-icon-size: var(--mush-chip-icon-size, 0.5em);
     --chip-avatar-padding: var(--mush-chip-avatar-padding, 0.1em);
     --chip-avatar-border-radius: var(--mush-chip-avatar-border-radius, 50%);
-    --chip-box-shadow: var(
-        --mush-chip-box-shadow,
-        var(
-            --ha-card-box-shadow,
-            none
-        )
-    );
     --chip-background: var(
         --mush-chip-background,
         var(--ha-card-background, var(--card-background-color, white))

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -35,9 +35,7 @@ export const themeVariables = css`
         --mush-chip-box-shadow,
         var(
             --ha-card-box-shadow,
-            0px 2px 1px -1px rgba(0, 0, 0, 0.2),
-            0px 1px 1px 0px rgba(0, 0, 0, 0.14),
-            0px 1px 3px 0px rgba(0, 0, 0, 0.12)
+            none
         )
     );
     --chip-background: var(


### PR DESCRIPTION
## Description

Cardq have a border instead of box-shadow by default.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have tested the change locally.
