### PR TITLE
Improve vacuum active state and add turn on/off command

### DIFF
--- a/src/cards/vacuum-card/controls/vacuum-commands-control.ts
+++ b/src/cards/vacuum-card/controls/vacuum-commands-control.ts
@@ -3,6 +3,7 @@ import { customElement, property } from "lit/decorators.js";
 import {
     computeRTL,
     HomeAssistant,
+    isActive,
     isAvailable,
     supportsFeature,
     VacuumEntity,
@@ -12,6 +13,8 @@ import {
     VACUUM_SUPPORT_RETURN_HOME,
     VACUUM_SUPPORT_START,
     VACUUM_SUPPORT_STOP,
+    VACUUM_SUPPORT_TURN_OFF,
+    VACUUM_SUPPORT_TURN_ON,
 } from "../../../ha";
 import { isCleaning, isReturningHome, isStopped } from "../utils";
 import { VacuumCommand } from "../vacuum-card-config";
@@ -27,6 +30,24 @@ export const isCommandsControlVisible = (entity: VacuumEntity, commands: VacuumC
     VACUUM_BUTTONS.some((item) => item.isVisible(entity, commands));
 
 export const VACUUM_BUTTONS: VacuumButton[] = [
+    {
+        icon: "mdi:power",
+        serviceName: "turn_on",
+        isVisible: (entity, commands) =>
+            supportsFeature(entity, VACUUM_SUPPORT_TURN_ON) &&
+            commands.includes("on_off") &&
+            !isActive(entity),
+        isDisabled: () => false,
+    },
+    {
+        icon: "mdi:power",
+        serviceName: "turn_off",
+        isVisible: (entity, commands) =>
+            supportsFeature(entity, VACUUM_SUPPORT_TURN_OFF) &&
+            commands.includes("on_off") &&
+            isActive(entity),
+        isDisabled: () => false,
+    },
     {
         icon: "mdi:play",
         serviceName: "start",

--- a/src/cards/vacuum-card/vacuum-card-config.ts
+++ b/src/cards/vacuum-card/vacuum-card-config.ts
@@ -9,6 +9,7 @@ import { EntitySharedConfig, entitySharedConfigStruct } from "../../shared/confi
 import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-config";
 
 export const VACUUM_COMMANDS = [
+    "on_off",
     "start_pause",
     "stop",
     "locate",

--- a/src/cards/vacuum-card/vacuum-card-editor.ts
+++ b/src/cards/vacuum-card/vacuum-card-editor.ts
@@ -17,18 +17,31 @@ import { VacuumCardConfig, vacuumCardConfigStruct, VACUUM_COMMANDS } from "./vac
 const VACUUM_LABELS = ["commands"];
 
 const computeSchema = memoizeOne(
-    (localize: LocalizeFunc, version: string, icon?: string): HaFormSchema[] => [
+    (
+        localize: LocalizeFunc,
+        customLocalize: LocalizeFunc,
+        version: string,
+        icon?: string
+    ): HaFormSchema[] => [
         { name: "entity", selector: { entity: { domain: VACUUM_ENTITY_DOMAINS } } },
         { name: "name", selector: { text: {} } },
         { name: "icon", selector: { icon: { placeholder: icon } } },
         ...APPEARANCE_FORM_SCHEMA,
         {
-            type: "multi_select",
             name: "commands",
-            options: VACUUM_COMMANDS.map((command) => [
-                command,
-                localize(`ui.dialogs.more_info_control.vacuum.${command}`),
-            ]) as [string, string][],
+            selector: {
+                select: {
+                    mode: "list",
+                    multiple: true,
+                    options: VACUUM_COMMANDS.map((command) => ({
+                        value: command,
+                        label:
+                            command === "on_off"
+                                ? customLocalize(`editor.card.vacuum.commands_list.${command}`)
+                                : localize(`ui.dialogs.more_info_control.vacuum.${command}`),
+                    })),
+                },
+            },
         },
         ...computeActionsFormSchema(version),
     ]
@@ -68,7 +81,13 @@ export class VacuumCardEditor extends MushroomBaseElement implements LovelaceCar
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;
         const entityIcon = entityState ? stateIcon(entityState) : undefined;
         const icon = this._config.icon || entityIcon;
-        const schema = computeSchema(this.hass!.localize, this.hass.connection.haVersion, icon);
+        const customLocalize = setupCustomlocalize(this.hass!);
+        const schema = computeSchema(
+            this.hass!.localize,
+            customLocalize,
+            this.hass.connection.haVersion,
+            icon
+        );
 
         return html`
             <ha-form

--- a/src/ha/data/entity.ts
+++ b/src/ha/data/entity.ts
@@ -24,14 +24,14 @@ export function isActive(entity: HassEntity) {
     // Custom cases
     switch (domain) {
         case "cover":
-            return state === "open" || state === "opening";
+            return !["close", "closing"].includes(state);
         case "device_tracker":
         case "person":
             return state !== "not_home";
         case "media_player":
             return state !== "idle" && state !== "standby";
         case "vacuum":
-            return state === "on" || state === "cleaning";
+            return !["idle", "docked", "paused"].includes(state);
         case "plant":
             return state === "problem";
         default:

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -98,7 +98,10 @@
                 "show_buttons_control": "Control buttons?"
             },
             "vacuum": {
-                "commands": "Commands"
+                "commands": "Commands",
+                "commands_list": {
+                    "on_off": "Turn on/off"
+                }
             },
             "media-player": {
                 "use_media_info": "Use media info",


### PR DESCRIPTION
## Description
- Add on/off command for vacuum (useful if your vacuum doesn't support)
- "Returning to dock" is now active state as the vacuum is moving.

## Related Issue
Fixes #835

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🌎 Translation (addition or update a translation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
- [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language
) if I add a new language .
