### PR TITLE
Fix title and subtitle alignment

### DIFF
--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -93,8 +93,8 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
 
         return html`
             <div class="header ${alignment}">
-                ${title ? html`<h1 class="title">${title}</h1>` : null}
-                ${subtitle ? html`<h2 class="subtitle">${subtitle}</h2>` : null}
+                ${title ? html`<h1 class="title">${title}</h1>` : html`<h1/>`}
+                ${subtitle ? html`<h2 class="subtitle">${subtitle}</h2>` : html`<h2/>`}
             </div>
         `;
     }


### PR DESCRIPTION
## Description
Fixes horizontal alignment between title and subtitle without changing/setting any sizes.

## Related Issue
[#812](https://github.com/piitaya/lovelace-mushroom/issues/812)

## Motivation and Context


## How Has This Been Tested

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
