### PR TITLE
added missing NL translations

### DIFF
--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -16,6 +16,14 @@
                     "none": "Geen"
                 }
             },
+            "icon_type_picker": {
+                "values": {
+                    "default": "Standaard icoon type",
+                    "icon": "Icoon",
+                    "entity-picture": "Entiteit afbeelding",
+                    "none": "Geen"
+                }
+            },
             "layout_picker": {
                 "values": {
                     "default": "Standaard lay-out",
@@ -37,8 +45,10 @@
             "generic": {
                 "icon_color": "Icoon kleur",
                 "layout": "Lay-out",
+                "fill_container": "Vul container",
                 "primary_info": "Primaire informatie",
                 "secondary_info": "Secundaire informatie",
+                "icon_type": "Icoon type",
                 "content_info": "Inhoud",
                 "use_entity_picture": "Gebruik entiteit afbeelding",
                 "collapsible_controls": "Bedieningselementen verbergen wanneer uitgeschakeld",
@@ -57,7 +67,8 @@
             },
             "cover": {
                 "show_buttons_control": "Toon knoppen",
-                "show_position_control": "Toon positie bediening"
+                "show_position_control": "Toon positie bediening",
+                "show_tilt_position_control": "Toon tilt control?"
             },
             "alarm_control_panel": {
                 "show_keypad": "Toon toetsenbord"
@@ -67,7 +78,10 @@
                 "secondary": "Secundaire informatie",
                 "multiline_secondary": "Meerlijnig secundair?",
                 "entity_extra": "Gebruikt in sjablonen en acties",
-                "content": "Inhoud"
+                "content": "Inhoud",
+                "badge_icon": "Badge icoon",
+                "badge_color": "Badge kleur",
+                "picture": "Afbeeling (zal het icoon vervangen)"
             },
             "title": {
                 "title": "Titel",
@@ -113,6 +127,13 @@
                 "lock": "Vergrendel",
                 "unlock": "Ontgrendel",
                 "open": "Open"
+            },
+            "humidifier": {
+                "show_target_humidity_control": "Vochtigheid controle?"
+            },
+            "climate": {
+                "show_temperature_control": "Temperatuur controle?",
+                "hvac_modes": "HVAC Modes"
             }
         },
         "chip": {


### PR DESCRIPTION
## Description

Added missing translation keys for Dutch (nl).

## Related Issue

none

## Motivation and Context

Adds missing translations.

## How Has This Been Tested

Tested in codespaces with the start:hass npm task.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [x] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
