### PR TITLE
Add icon color selection for light card

### DIFF
--- a/docs/cards/light.md
+++ b/docs/cards/light.md
@@ -15,6 +15,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | :------------------------ | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
 | `entity`                  | string                                              | Required    | Light entity                                                                        |
 | `icon`                    | string                                              | Optional    | Custom icon                                                                         |
+| `icon_color`              | string                                              | `blue`      | Custom color for icon and brightness bar when the lights is on and `use_light_color` is `false`
 | `name`                    | string                                              | Optional    | Custom name                                                                         |
 | `layout`                  | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
 | `fill_container`          | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |

--- a/src/cards/light-card/light-card-config.ts
+++ b/src/cards/light-card/light-card-config.ts
@@ -1,4 +1,4 @@
-import { assign, boolean, object, optional } from "superstruct";
+import { assign, boolean, object, optional, string } from "superstruct";
 import { LovelaceCardConfig } from "../../ha";
 import { ActionsSharedConfig, actionsSharedConfigStruct } from "../../shared/config/actions-config";
 import {
@@ -12,6 +12,7 @@ export type LightCardConfig = LovelaceCardConfig &
     EntitySharedConfig &
     AppearanceSharedConfig &
     ActionsSharedConfig & {
+        icon_color?: string;
         show_brightness_control?: boolean;
         show_color_temp_control?: boolean;
         show_color_control?: boolean;
@@ -23,6 +24,7 @@ export const lightCardConfigStruct = assign(
     lovelaceCardConfigStruct,
     assign(entitySharedConfigStruct, appearanceSharedConfigStruct, actionsSharedConfigStruct),
     object({
+        icon_color: optional(string()),
         show_brightness_control: optional(boolean()),
         show_color_temp_control: optional(boolean()),
         show_color_control: optional(boolean()),

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -24,7 +24,14 @@ export const LIGHT_LABELS = [
 const computeSchema = memoizeOne((version: string, icon?: string): HaFormSchema[] => [
     { name: "entity", selector: { entity: { domain: LIGHT_ENTITY_DOMAINS } } },
     { name: "name", selector: { text: {} } },
-    { name: "icon", selector: { icon: { placeholder: icon } } },
+    {
+        type: "grid",
+        name: "",
+        schema: [
+            { name: "icon", selector: { icon: { placeholder: icon } } },
+            { name: "icon_color", selector: { "mush-color": {} } },
+        ],
+    },
     ...APPEARANCE_FORM_SCHEMA,
     {
         type: "grid",

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -25,6 +25,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { computeEntityPicture, computeInfoDisplay } from "../../utils/info";
@@ -213,6 +214,7 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         const lightRgbColor = getRGBColor(entity);
         const active = isActive(entity);
         const iconStyle = {};
+        const iconColor = this._config?.icon_color;
         if (lightRgbColor && this._config?.use_light_color) {
             const color = lightRgbColor.join(",");
             iconStyle["--icon-color"] = `rgb(${color})`;
@@ -223,6 +225,10 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
                     iconStyle["--icon-color"] = `rgba(var(--rgb-primary-text-color), 0.2)`;
                 }
             }
+        } else if (iconColor) {
+            const iconRgbColor = computeRgbColor(iconColor);
+            iconStyle["--icon-color"] = `rgb(${iconRgbColor})`;
+            iconStyle["--shape-color"] = `rgba(${iconRgbColor}, 0.2)`;
         }
         return html`
             <mushroom-shape-icon
@@ -254,6 +260,7 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
             case "brightness_control":
                 const lightRgbColor = getRGBColor(entity);
                 const sliderStyle = {};
+                const iconColor = this._config?.icon_color;
                 if (lightRgbColor && this._config?.use_light_color) {
                     const color = lightRgbColor.join(",");
                     sliderStyle["--slider-color"] = `rgb(${color})`;
@@ -264,6 +271,10 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
                         ] = `rgba(var(--rgb-primary-text-color), 0.05)`;
                         sliderStyle["--slider-color"] = `rgba(var(--rgb-primary-text-color), 0.15)`;
                     }
+                } else if (iconColor) {
+                    const iconRgbColor = computeRgbColor(iconColor);
+                    sliderStyle["--slider-color"] = `rgb(${iconRgbColor})`;
+                    sliderStyle["--slider-bg-color"] = `rgba(${iconRgbColor}, 0.2)`;
                 }
                 return html`
                     <mushroom-light-brightness-control


### PR DESCRIPTION
## Description

Add the possibility to set a color for the Light card like for the Entity card. Changes the color of an icon and a brightness bar only if `use_light_color` is `false`.

<img width="519" alt="Screenshot 2023-01-05 at 18 13 21" src="https://user-images.githubusercontent.com/1819786/210828061-59114aff-8cbd-4fc2-b760-960b857cd81f.png">
<img width="511" alt="Screenshot 2023-01-05 at 18 16 00" src="https://user-images.githubusercontent.com/1819786/210828173-c6469e64-905b-478a-8043-d0939d77d161.png">

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #706 

## Motivation and Context

Have no idea why not. I want to be able to make all cards for a single room to have a single color. I can't do this with the current light card functionality.

## How Has This Been Tested

Tested on a local demo environment with all possible card configuration options.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
