### PR TITLE
Documentation: Add a note about the variable for the entity on the template card

### DIFF
--- a/docs/cards/template.md
+++ b/docs/cards/template.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-A template card allow you to build custom card.
+A template card allow you to build custom card. You can use `entity` as a variable for the entity set on the card e.g. `{{ states(entity) }}`.
 
 ## Configuration variables
 


### PR DESCRIPTION
## Description

The template card didn't note that the entity could be used as a variable.

## Related Issue

This is related to #713 as the user used the wrong syntax and this may help :)

## Motivation and Context

I didn't know how I could access the entity set on the card in templating and only found it by searching the issues and forums. It seems like it's a small but useful change .

## How Has This Been Tested

This is just a documentation change. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
