### PR TITLE
Update utils.ts to support icloud3 Stationary

### DIFF
--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -5,7 +5,7 @@ export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "mdi:help";
-    } else if (state === "not_home") {
+    } else if (state === "not_home" || state == "Stationary") {
         return "mdi:home-export-outline";
     } else if (state === "home") {
         return "mdi:home";
@@ -23,7 +23,7 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "var(--rgb-state-person-unknown)";
-    } else if (state === "not_home") {
+    } else if (state === "not_home" || state == "Stationary") {
         return "var(--rgb-state-person-not-home)";
     } else if (state === "home") {
         return "var(--rgb-state-person-home)";

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -5,12 +5,15 @@ export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "mdi:help";
-    } else if (state === "not_home" || state === "Stationary") {
+    } else if (state === "not_home") {
         return "mdi:home-export-outline";
     } else if (state === "home") {
         return "mdi:home";
+    }  else {
+        return "mdi:map-marker-radius";
     }
-
+ 
+    
     const zone = zones.find((z) => state === z.attributes.friendly_name);
     if (zone && zone.attributes.icon) {
         return zone.attributes.icon;
@@ -23,10 +26,12 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "var(--rgb-state-person-unknown)";
-    } else if (state === "not_home" || state === "Stationary") {
+    } else if (state === "not_home") {
         return "var(--rgb-state-person-not-home)";
     } else if (state === "home") {
         return "var(--rgb-state-person-home)";
+    } else {
+        return "var(--rgb-state-person-not-home)";;
     }
     const isInZone = zones.some((z) => state === z.attributes.friendly_name);
     if (isInZone) {

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -5,7 +5,7 @@ export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "mdi:help";
-    } else if (state === "not_home" || state == "Stationary") {
+    } else if (state === "not_home" || state === "Stationary") {
         return "mdi:home-export-outline";
     } else if (state === "home") {
         return "mdi:home";
@@ -23,7 +23,7 @@ export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
     const state = entity.state;
     if (state === UNKNOWN) {
         return "var(--rgb-state-person-unknown)";
-    } else if (state === "not_home" || state == "Stationary") {
+    } else if (state === "not_home" || state === "Stationary") {
         return "var(--rgb-state-person-not-home)";
     } else if (state === "home") {
         return "var(--rgb-state-person-home)";


### PR DESCRIPTION
icloud3 creates a Stationary Zone when you are stationary

## Description

Added the a new state to the away icon

## Related Issue

see issue "Amend person card logic to allow for room presence #353"

This PR fixes or closes issue: fixes 

## Motivation and Context

Wrong display : Person is shown at home when it is not

## Types of changes

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
