### PR TITLE
Add mushroom ressource to config

### DIFF
--- a/.hass_dev/configuration.yaml
+++ b/.hass_dev/configuration.yaml
@@ -14,4 +14,6 @@ lovelace: !include lovelace.yaml
 
 frontend:
   themes: !include_dir_merge_named themes
+  extra_module_url:
+    - http://localhost:4000/mushroom.js
 #   development_repo: /workspaces/home-assistant-frontend

--- a/README.md
+++ b/README.md
@@ -119,14 +119,6 @@ npm start
 
 Server will start on port `4000`.
 
-### Home assistant configuration
-
-Once both Home Assistant and mushroom are running, you have to add a resource to Home Assistant UI:
-
--   Enable `Advanced Mode` in your profile page
--   Go to Dashboard Resources and add the resource `http://localhost:4000/mushroom.js`:  
-    _Settings_ → _Dashboards_ → _More Options icon_ → _Resources_ → _Add Resource_ → Set _URL_ as `http://localhost:4000/mushroom.js` → Set _Resource type_ as `JavaScript Module`.
-
 ### Build
 
 You can build the `mushroom.js` file in `dist` folder by running the build command.


### PR DESCRIPTION
## Description

Developers do not need to add the ressource from the UI. It's automatically done via the config.
`http://localhost:4000/mushroom.js` can be removed from ressources.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
