### PR TITLE
Add support for entity component translations

### DIFF
--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -77,7 +77,8 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
 
         const iconStyle = {};

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -70,7 +70,8 @@ export class EntityChip extends LitElement implements LovelaceChip {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
 
         const active = isActive(entity);

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -76,7 +76,8 @@ export class LightChip extends LitElement implements LovelaceChip {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
 
         const active = isActive(entity);

--- a/src/cards/chips-card/chips/weather-chip.ts
+++ b/src/cards/chips-card/chips/weather-chip.ts
@@ -65,7 +65,8 @@ export class WeatherChip extends LitElement implements LovelaceChip {
                 this.hass.localize,
                 entity,
                 this.hass.locale,
-                this.hass.entities
+                this.hass.entities,
+                this.hass.connection.haVersion,
             );
             displayLabels.push(stateDisplay);
         }

--- a/src/cards/climate-card/climate-card-editor.ts
+++ b/src/cards/climate-card/climate-card-editor.ts
@@ -2,7 +2,7 @@ import { html, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
-import { fireEvent, LocalizeFunc, LovelaceCardEditor } from "../../ha";
+import { atLeastHaVersion, fireEvent, LocalizeFunc, LovelaceCardEditor } from "../../ha";
 import setupCustomlocalize from "../../localize";
 import { computeActionsFormSchema } from "../../shared/config/actions-config";
 import { APPEARANCE_FORM_SCHEMA } from "../../shared/config/appearance-config";
@@ -16,34 +16,38 @@ import { ClimateCardConfig, climateCardConfigStruct, HVAC_MODES } from "./climat
 
 const CLIMATE_LABELS = ["hvac_modes", "show_temperature_control"] as string[];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc, icon?: string): HaFormSchema[] => [
-    { name: "entity", selector: { entity: { domain: CLIMATE_ENTITY_DOMAINS } } },
-    { name: "name", selector: { text: {} } },
-    { name: "icon", selector: { icon: { placeholder: icon } } },
-    ...APPEARANCE_FORM_SCHEMA,
-    {
-        type: "grid",
-        name: "",
-        schema: [
-            {
-                name: "hvac_modes",
-                selector: {
-                    select: {
-                        options: HVAC_MODES.map((mode) => ({
-                            value: mode,
-                            label: localize(`component.climate.state._.${mode}`),
-                        })),
-                        mode: "dropdown",
-                        multiple: true,
+const computeSchema = memoizeOne(
+    (localize: LocalizeFunc, haVersion: string, icon?: string): HaFormSchema[] => [
+        { name: "entity", selector: { entity: { domain: CLIMATE_ENTITY_DOMAINS } } },
+        { name: "name", selector: { text: {} } },
+        { name: "icon", selector: { icon: { placeholder: icon } } },
+        ...APPEARANCE_FORM_SCHEMA,
+        {
+            type: "grid",
+            name: "",
+            schema: [
+                {
+                    name: "hvac_modes",
+                    selector: {
+                        select: {
+                            options: HVAC_MODES.map((mode) => ({
+                                value: mode,
+                                label: atLeastHaVersion(haVersion, 2023, 4, 0)
+                                    ? localize(`component.climate.entity_component._.state.${mode}`)
+                                    : localize(`component.climate.state._.${mode}`),
+                            })),
+                            mode: "dropdown",
+                            multiple: true,
+                        },
                     },
                 },
-            },
-            { name: "show_temperature_control", selector: { boolean: {} } },
-            { name: "collapsible_controls", selector: { boolean: {} } },
-        ],
-    },
-    ...computeActionsFormSchema(),
-]);
+                { name: "show_temperature_control", selector: { boolean: {} } },
+                { name: "collapsible_controls", selector: { boolean: {} } },
+            ],
+        },
+        ...computeActionsFormSchema(),
+    ]
+);
 
 @customElement(CLIMATE_CARD_EDITOR_NAME)
 export class ClimateCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
@@ -79,7 +83,7 @@ export class ClimateCardEditor extends MushroomBaseElement implements LovelaceCa
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;
         const entityIcon = entityState ? stateIcon(entityState) : undefined;
         const icon = this._config.icon || entityIcon;
-        const schema = computeSchema(this.hass!.localize, icon);
+        const schema = computeSchema(this.hass!.localize, this.hass!.connection.haVersion, icon);
 
         return html`
             <ha-form

--- a/src/cards/climate-card/climate-card-editor.ts
+++ b/src/cards/climate-card/climate-card-editor.ts
@@ -32,9 +32,11 @@ const computeSchema = memoizeOne(
                         select: {
                             options: HVAC_MODES.map((mode) => ({
                                 value: mode,
-                                label: atLeastHaVersion(haVersion, 2023, 4, 0)
-                                    ? localize(`component.climate.entity_component._.state.${mode}`)
-                                    : localize(`component.climate.state._.${mode}`),
+                                label: localize(
+                                    atLeastHaVersion(haVersion, 2023, 4)
+                                        ? `component.climate.entity_component._.state.${mode}`
+                                        : `component.climate.state._.${mode}`
+                                ),
                             })),
                             mode: "dropdown",
                             multiple: true,

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -149,7 +149,8 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
         if (entity.attributes.current_temperature !== null) {
             const temperature = formatNumber(

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -165,7 +165,8 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
         if (this.position) {
             stateDisplay += ` - ${this.position}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -124,7 +124,8 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
         if (this.percentage != null) {
             stateDisplay = `${this.percentage}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/humidifier-card/humidifier-card.ts
+++ b/src/cards/humidifier-card/humidifier-card.ts
@@ -106,7 +106,8 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
         if (this.humidity) {
             stateDisplay = `${this.humidity}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -180,7 +180,8 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
         if (this.brightness != null) {
             stateDisplay = `${this.brightness}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/media-player-card/utils.ts
+++ b/src/cards/media-player-card/utils.ts
@@ -51,7 +51,13 @@ export function computeMediaStateDisplay(
     entity: MediaPlayerEntity,
     hass: HomeAssistant
 ): string {
-    let state = computeStateDisplay(hass.localize, entity, hass.locale, hass.entities);
+    let state = computeStateDisplay(
+        hass.localize,
+        entity,
+        hass.locale,
+        hass.entities,
+        hass.connection.haVersion
+    );
     if (![UNAVAILABLE, UNKNOWN, OFF].includes(entity.state) && config.use_media_info) {
         return computeMediaDescription(entity) || state;
     }

--- a/src/cards/number-card/number-card.ts
+++ b/src/cards/number-card/number-card.ts
@@ -105,7 +105,8 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion,
         );
         if (this.value !== undefined) {
             const numberValue = formatNumber(

--- a/src/ha/common/entity/compute-state-display.ts
+++ b/src/ha/common/entity/compute-state-display.ts
@@ -3,6 +3,7 @@ import { UNAVAILABLE, UNKNOWN } from "../../data/entity";
 import { FrontendLocaleData } from "../../data/translation";
 import { updateIsInstallingFromAttributes, UPDATE_SUPPORT_PROGRESS } from "../../data/update";
 import { EntityRegistryDisplayEntry, HomeAssistant } from "../../types";
+import { atLeastHaVersion } from "../../util";
 import { formatDuration, UNIT_TO_SECOND_CONVERT } from "../datetime/duration";
 import { formatDate } from "../datetime/format_date";
 import { formatDateTime } from "../datetime/format_date_time";
@@ -22,12 +23,14 @@ export const computeStateDisplay = (
     stateObj: HassEntity,
     locale: FrontendLocaleData,
     entities: HomeAssistant["entities"],
+    haVersion: string,
     state?: string
 ): string =>
     computeStateDisplayFromEntityAttributes(
         localize,
         locale,
         entities,
+        haVersion,
         stateObj.entity_id,
         stateObj.attributes,
         state !== undefined ? state : stateObj.state
@@ -37,6 +40,7 @@ export const computeStateDisplayFromEntityAttributes = (
     localize: LocalizeFunc,
     locale: FrontendLocaleData,
     entities: HomeAssistant["entities"],
+    haVersion: string,
     entityId: string,
     attributes: any,
     state: string
@@ -191,6 +195,24 @@ export const computeStateDisplayFromEntityAttributes = (
             : attributes.skipped_version === attributes.latest_version
             ? attributes.latest_version ?? localize("state.default.unavailable")
             : localize("ui.card.update.up_to_date");
+    }
+
+    if (atLeastHaVersion(haVersion, 2023, 4, 0)) {
+        return (
+            (entity?.translation_key &&
+                localize(
+                    `component.${entity.platform}.entity.${domain}.${entity.translation_key}.state.${state}`
+                )) ||
+            // Return device class translation
+            (attributes.device_class &&
+                localize(
+                    `component.${domain}.entity_component.${attributes.device_class}.state.${state}`
+                )) ||
+            // Return default translation
+            localize(`component.${domain}.entity_component._.state.${state}`) ||
+            // We don't know! Return the raw state.
+            state
+        );
     }
 
     return (

--- a/src/ha/common/entity/compute-state-display.ts
+++ b/src/ha/common/entity/compute-state-display.ts
@@ -197,24 +197,6 @@ export const computeStateDisplayFromEntityAttributes = (
             : localize("ui.card.update.up_to_date");
     }
 
-    if (atLeastHaVersion(haVersion, 2023, 4, 0)) {
-        return (
-            (entity?.translation_key &&
-                localize(
-                    `component.${entity.platform}.entity.${domain}.${entity.translation_key}.state.${state}`
-                )) ||
-            // Return device class translation
-            (attributes.device_class &&
-                localize(
-                    `component.${domain}.entity_component.${attributes.device_class}.state.${state}`
-                )) ||
-            // Return default translation
-            localize(`component.${domain}.entity_component._.state.${state}`) ||
-            // We don't know! Return the raw state.
-            state
-        );
-    }
-
     return (
         (entity?.translation_key &&
             localize(
@@ -222,9 +204,17 @@ export const computeStateDisplayFromEntityAttributes = (
             )) ||
         // Return device class translation
         (attributes.device_class &&
-            localize(`component.${domain}.state.${attributes.device_class}.${state}`)) ||
+            localize(
+                atLeastHaVersion(haVersion, 2023, 4)
+                    ? `component.${domain}.entity_component.${attributes.device_class}.state.${state}`
+                    : `component.${domain}.state.${attributes.device_class}.${state}`
+            )) ||
         // Return default translation
-        localize(`component.${domain}.state._.${state}`) ||
+        localize(
+            atLeastHaVersion(haVersion, 2023, 4)
+                ? `component.${domain}.entity_component._.state.${state}`
+                : `component.${domain}.state._.${state}`
+        ) ||
         // We don't know! Return the raw state.
         state
     );

--- a/src/utils/base-card.ts
+++ b/src/utils/base-card.ts
@@ -59,7 +59,8 @@ export class MushroomBaseCard extends MushroomBaseElement {
             this.hass.localize,
             entity,
             this.hass.locale,
-            this.hass.entities
+            this.hass.entities,
+            this.hass.connection.haVersion
         );
         const displayState = state ?? defaultState;
 


### PR DESCRIPTION
## Description

Following https://github.com/home-assistant/frontend/pull/15820, `2023.4`version will introduce entity component translations. The translation key needs to be adjusted.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
