### PR TITLE
Fan Card Presets

### DIFF
--- a/docs/cards/fan.md
+++ b/docs/cards/fan.md
@@ -9,13 +9,15 @@ A fan card allows you to control a fan entity.
 
 ## Configuration variables
 
-All the options are available in the lovelace editor but you can use `yaml` if you want.
+Almost all the options are available in the lovelace editor but you can use `yaml` if you want.
+
 
 | Name                      | Type                                                | Default     | Description                                                                         |
 | :------------------------ | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
 | `entity`                  | string                                              | Required    | Fan entity                                                                          |
 | `icon`                    | string                                              | Optional    | Custom icon                                                                         |
 | `name`                    | string                                              | Optional    | Custom name                                                                         |
+| `presets`                 | preset list                                         | Optional    | list of persentage presets and coresponding icons                                   |
 | `layout`                  | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
 | `fill_container`          | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
 | `primary_info`            | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                        |
@@ -28,3 +30,12 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `tap_action`              | action                                              | `toggle`    | Home assistant action to perform on tap                                             |
 | `hold_action`             | action                                              | `more-info` | Home assistant action to perform on hold                                            |
 | `double_tap_action`       | action                                              | `more-info` | Home assistant action to perform on double_tap                                      |
+
+### presets
+
+presets are entered as a list of objects value and icon
+
+| Name                      | Type                                                | Default     | Description                                                                         |
+| :------------------------ | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
+| `value`                   | integer                                             | Required    | 0-100 representing the percentage for the preset                                    |
+| `icon`                    | string                                              | Optional    | Custom icon (defaults to mdi:fan)                                                   |

--- a/docs/cards/fan.md
+++ b/docs/cards/fan.md
@@ -17,7 +17,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `entity`                  | string                                              | Required    | Fan entity                                                                          |
 | `icon`                    | string                                              | Optional    | Custom icon                                                                         |
 | `name`                    | string                                              | Optional    | Custom name                                                                         |
-| `presets`                 | preset list                                         | Optional    | list of persentage presets and coresponding icons                                   |
+| `custom_presets`          | preset list                                         | Optional    | list of percentage presets and coresponding icons                                   |
 | `layout`                  | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
 | `fill_container`          | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
 | `primary_info`            | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                        |
@@ -31,11 +31,11 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `hold_action`             | action                                              | `more-info` | Home assistant action to perform on hold                                            |
 | `double_tap_action`       | action                                              | `more-info` | Home assistant action to perform on double_tap                                      |
 
-### presets
+### Custom presets
 
-presets are entered as a list of objects value and icon
+custom_presets are entered as a list of objects value and icon
 
 | Name                      | Type                                                | Default     | Description                                                                         |
 | :------------------------ | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
-| `value`                   | integer                                             | Required    | 0-100 representing the percentage for the preset                                    |
+| `percentage`              | integer                                             | Required    | 0-100 representing the percentage for the preset                                    |
 | `icon`                    | string                                              | Optional    | Custom icon (defaults to mdi:fan)                                                   |

--- a/docs/cards/fan.md
+++ b/docs/cards/fan.md
@@ -9,7 +9,7 @@ A fan card allows you to control a fan entity.
 
 ## Configuration variables
 
-Almost all the options are available in the lovelace editor but you can use `yaml` if you want.
+All the options are available in the lovelace editor but you can use `yaml` if you want.
 
 
 | Name                      | Type                                                | Default     | Description                                                                         |

--- a/src/cards/fan-card/controls/fan-preset-control.ts
+++ b/src/cards/fan-card/controls/fan-preset-control.ts
@@ -1,0 +1,90 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { HomeAssistant, isActive, isAvailable } from "../../../ha";
+import "../../../shared/slider";
+import { getPercentage } from "../utils";
+import { FanCardConfig } from "../fan-card-config";
+import { classMap } from "lit/directives/class-map.js";
+
+@customElement("mushroom-fan-preset-control")
+export class FanPresetControl extends LitElement {
+    @property({ attribute: false }) public hass!: HomeAssistant;
+    @property({ attribute: false }) public entity!: HassEntity;
+    @property({ attribute: false }) public config!: FanCardConfig;
+
+    onChange(e: CustomEvent<{ value: number }>): void {
+        const value = e.detail.value;
+        this.hass.callService("fan", "set_percentage", {
+            entity_id: this.entity.entity_id,
+            percentage: value,
+        });
+    }
+
+    onCurrentChange(e: CustomEvent<{ value?: number }>): void {
+        const value = e.detail.value;
+        this.dispatchEvent(
+            new CustomEvent("current-change", {
+                detail: {
+                    value,
+                },
+            })
+        );
+    }
+
+    private _onTap(e: MouseEvent): void {
+        e.stopPropagation();
+        const value = this.config.presets?.find(f=>`fan-preset-${f.value}` === (e.target as Element).id)?.value;
+        if(value === 0 || value) {
+            this.hass.callService("fan", "set_percentage", {
+                entity_id: this.entity.entity_id,
+                percentage: value,
+            });
+    
+            this.dispatchEvent(
+                new CustomEvent("current-change", {
+                    detail: {
+                        value,
+                    },
+                })
+            );
+        }
+    }
+
+    protected render(): TemplateResult {
+        const active = isActive(this.entity);
+        const percentage = getPercentage(this.entity);
+
+        return html`
+            ${this.config.presets?.map(preset => {
+            const activated = active && preset.value === percentage;
+            return html`
+                <mushroom-button
+                    .disabled=${!isAvailable(this.entity)}
+                    .icon=${preset.icon || "mdi:fan"}
+                    @click=${this._onTap}
+                     class=${classMap({ active: activated })}
+                    .id=${'fan-preset-'+preset.value}
+                />`
+            })}
+        `;
+    }
+
+    static get styles(): CSSResultGroup {
+        return css`
+            :host {
+                display: flex;
+            }
+            mushroom-button.active {
+                --icon-color: rgb(var(--rgb-state-fan));
+                --bg-color: rgba(var(--rgb-state-fan), 0.2);
+            }
+            mushroom-button {
+                flex: 1
+            }
+            mushroom-button:not(:last-child) {
+                margin-right: var(--spacing);
+            }
+        `;
+    }
+}

--- a/src/cards/fan-card/controls/fan-preset-control.ts
+++ b/src/cards/fan-card/controls/fan-preset-control.ts
@@ -34,7 +34,7 @@ export class FanPresetControl extends LitElement {
 
     private _onTap(e: MouseEvent): void {
         e.stopPropagation();
-        const value = this.config.presets?.find(f=>`fan-preset-${f.value}` === (e.target as Element).id)?.value;
+        const value = this.config.custom_presets?.find(f=>`fan-preset-${f.value}` === (e.target as Element).id)?.value;
         if(value === 0 || value) {
             this.hass.callService("fan", "set_percentage", {
                 entity_id: this.entity.entity_id,
@@ -56,7 +56,7 @@ export class FanPresetControl extends LitElement {
         const percentage = getPercentage(this.entity);
 
         return html`
-            ${this.config.presets?.map(preset => {
+            ${this.config.custom_presets?.map(preset => {
             const activated = active && preset.value === percentage;
             return html`
                 <mushroom-button

--- a/src/cards/fan-card/controls/fan-preset-control.ts
+++ b/src/cards/fan-card/controls/fan-preset-control.ts
@@ -34,7 +34,7 @@ export class FanPresetControl extends LitElement {
 
     private _onTap(e: MouseEvent): void {
         e.stopPropagation();
-        const value = this.config.custom_presets?.find(f=>`fan-preset-${f.value}` === (e.target as Element).id)?.value;
+        const value = this.config.custom_presets?.find(f=>`fan-preset-${f.percentage}` === (e.target as Element).id)?.percentage;
         if(value === 0 || value) {
             this.hass.callService("fan", "set_percentage", {
                 entity_id: this.entity.entity_id,
@@ -57,14 +57,14 @@ export class FanPresetControl extends LitElement {
 
         return html`
             ${this.config.custom_presets?.map(preset => {
-            const activated = active && preset.value === percentage;
+            const activated = active && preset.percentage === percentage;
             return html`
                 <mushroom-button
                     .disabled=${!isAvailable(this.entity)}
                     .icon=${preset.icon || "mdi:fan"}
                     @click=${this._onTap}
                      class=${classMap({ active: activated })}
-                    .id=${'fan-preset-'+preset.value}
+                    .id=${'fan-preset-'+preset.percentage}
                 />`
             })}
         `;

--- a/src/cards/fan-card/fan-card-config.ts
+++ b/src/cards/fan-card/fan-card-config.ts
@@ -9,7 +9,7 @@ import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-conf
 import { LovelaceCardConfig } from "../../ha";
 
 export interface FanPresetConfig {
-    value: number;
+    percentage: number;
     icon?: string;
 }
 
@@ -33,7 +33,7 @@ export const fanCardConfigStruct = assign(
         show_oscillate_control: optional(boolean()),
         collapsible_controls: optional(boolean()),
         custom_presets: optional(array(object({
-            value: integer(),
+            percentage: integer(),
             icon: optional(string())
         })))
     })

--- a/src/cards/fan-card/fan-card-config.ts
+++ b/src/cards/fan-card/fan-card-config.ts
@@ -1,4 +1,4 @@
-import { assign, boolean, object, optional } from "superstruct";
+import { assign, boolean, object, optional, array, string, integer  } from "superstruct";
 import { actionsSharedConfigStruct, ActionsSharedConfig } from "../../shared/config/actions-config";
 import {
     appearanceSharedConfigStruct,
@@ -8,6 +8,11 @@ import { entitySharedConfigStruct, EntitySharedConfig } from "../../shared/confi
 import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-config";
 import { LovelaceCardConfig } from "../../ha";
 
+export interface FanPresetConfig {
+    value: number;
+    icon?: string;
+}
+
 export type FanCardConfig = LovelaceCardConfig &
     EntitySharedConfig &
     AppearanceSharedConfig &
@@ -16,6 +21,7 @@ export type FanCardConfig = LovelaceCardConfig &
         show_percentage_control?: boolean;
         show_oscillate_control?: boolean;
         collapsible_controls?: boolean;
+        presets? : FanPresetConfig[];
     };
 
 export const fanCardConfigStruct = assign(
@@ -26,5 +32,9 @@ export const fanCardConfigStruct = assign(
         show_percentage_control: optional(boolean()),
         show_oscillate_control: optional(boolean()),
         collapsible_controls: optional(boolean()),
+        presets: optional(array(object({
+            value: integer(),
+            icon: optional(string())
+        })))
     })
 );

--- a/src/cards/fan-card/fan-card-config.ts
+++ b/src/cards/fan-card/fan-card-config.ts
@@ -21,7 +21,7 @@ export type FanCardConfig = LovelaceCardConfig &
         show_percentage_control?: boolean;
         show_oscillate_control?: boolean;
         collapsible_controls?: boolean;
-        presets? : FanPresetConfig[];
+        custom_presets? : FanPresetConfig[];
     };
 
 export const fanCardConfigStruct = assign(
@@ -32,7 +32,7 @@ export const fanCardConfigStruct = assign(
         show_percentage_control: optional(boolean()),
         show_oscillate_control: optional(boolean()),
         collapsible_controls: optional(boolean()),
-        presets: optional(array(object({
+        custom_presets: optional(array(object({
             value: integer(),
             icon: optional(string())
         })))

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -13,8 +13,12 @@ import { stateIcon } from "../../utils/icons/state-icon";
 import { loadHaComponents } from "../../utils/loader";
 import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import { FanCardConfig, fanCardConfigStruct } from "./fan-card-config";
+import '../../shared/button'
 
 const FAN_LABELS = ["icon_animation", "show_percentage_control", "show_oscillate_control"];
+
+const mdiClose = "M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z";
+const mdiPlus = "M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z";
 
 const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
     { name: "entity", selector: { entity: { domain: FAN_ENTITY_DOMAINS } } },
@@ -40,6 +44,17 @@ const computeSchema = memoizeOne((icon?: string): HaFormSchema[] => [
     ...computeActionsFormSchema(),
 ]);
 
+const customPresetsScheme: HaFormSchema[] = [
+    {
+        type: "grid",
+        name: "",
+        schema: [
+            { name: "icon", selector: { icon: { placeholder: 'mdi:fan' } } },
+            { name: "value", selector: { number: {min: 0, max: 100, step: 1, mode: 'box'} } }
+        ]
+    }
+];
+
 @customElement(FAN_CARD_EDITOR_NAME)
 export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
     @state() private _config?: FanCardConfig;
@@ -53,6 +68,8 @@ export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEd
         assert(config, fanCardConfigStruct);
         this._config = config;
     }
+
+    private _customLocalize = setupCustomlocalize(this.hass!);
 
     private _computeLabel = (schema: HaFormSchema) => {
         const customLocalize = setupCustomlocalize(this.hass!);
@@ -84,10 +101,99 @@ export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEd
                 .computeLabel=${this._computeLabel}
                 @value-changed=${this._valueChanged}
             ></ha-form>
+            <div class="root">
+                <h3>${this._customLocalize('editor.card.fan.custom_presets.title')}</h3>
+                ${this._config.custom_presets?.map((preset, index) => {
+                    return html`
+                        <div class="custom-preset-row">
+                            <ha-form
+                                .hass=${this.hass}
+                                .data=${preset}
+                                .schema=${customPresetsScheme}
+                                .computeLabel=${this._computeLabel}
+                                @value-changed=${this._presetValueChanged}
+                                .index=${index}
+                            ></ha-form>
+                            <ha-icon-button
+                                .label=${this._customLocalize('editor.card.fan.custom_presets.remove')}
+                                .path=${mdiClose}
+                                class="remove-icon"
+                                .index=${index}
+                                @click=${this._removeRow}
+                                >
+                            </ha-icon-button>
+                        </div>
+                    `
+                })}
+                <ha-icon-button
+                .label=${this._customLocalize('editor.card.fan.custom_presets.add')}
+                .path=${mdiPlus}
+                class="plus-icon"
+                @click=${this._addRow}
+            ></ha-icon-button>
+            </div>
         `;
     }
 
+    private _removeRow(ev: CustomEvent): void {
+        const index = (ev.currentTarget as any).index;
+        const newCustomPresets = this._config!.custom_presets!.concat();
+    
+        newCustomPresets.splice(index, 1);
+
+        this._config!.custom_presets = newCustomPresets.length === 0 ? undefined : newCustomPresets;
+    
+        fireEvent(this, "config-changed", { config: this._config! });
+      }
+
+    private _addRow(): void {
+        const newCustomPresets = (this._config!.custom_presets || []).concat();
+    
+        newCustomPresets.push({
+            icon: 'mdi:fan',
+            value: 100
+        })
+
+        this._config!.custom_presets = newCustomPresets;
+    
+        fireEvent(this, "config-changed", { config: this._config! });
+      }
+
     private _valueChanged(ev: CustomEvent): void {
         fireEvent(this, "config-changed", { config: ev.detail.value });
+    }
+
+    private _presetValueChanged(ev: CustomEvent): void {
+        const index = (ev.currentTarget as any).index;
+        const newCustomPresets = this._config!.custom_presets!.concat();
+        newCustomPresets[index] = {...ev.detail.value};
+        this._config!.custom_presets = newCustomPresets;
+    
+        fireEvent(this, "config-changed", { config: this._config! });
+    }
+
+    static get styles(): CSSResultGroup {
+        return [
+            css`
+                .remove-icon,
+                .plus-icon {
+                --mdc-icon-button-size: 36px;
+                color: var(--secondary-text-color);
+                }
+                .custom-preset-row {
+                    display: flex;
+                    gap: 8px;
+                    margin-bottom: 16px;
+                }
+                .custom-preset-row ha-form {
+                    flex: 1
+                }
+                .custom-preset-row ha-icon-button,
+                .custom-preset-row button {
+                    flex-shring: 1;
+                    flex-basis: 0%;
+                }
+            `
+        ]
     }
 }

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -15,7 +15,7 @@ import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import { FanCardConfig, fanCardConfigStruct } from "./fan-card-config";
 import '../../shared/button'
 
-const FAN_LABELS = ["icon_animation", "show_percentage_control", "show_oscillate_control"];
+const FAN_LABELS = ["icon_animation", "show_percentage_control", "show_oscillate_control", "custom_presets"];
 
 const mdiClose = "M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z";
 const mdiPlus = "M19,13H13V19H11V13H5V11H11V5H13V11H19V13Z";
@@ -50,7 +50,7 @@ const customPresetsScheme: HaFormSchema[] = [
         name: "",
         schema: [
             { name: "icon", selector: { icon: { placeholder: 'mdi:fan' } } },
-            { name: "value", selector: { number: {min: 0, max: 100, step: 1, mode: 'box'} } }
+            { name: "percentage", selector: { number: {min: 0, max: 100, step: 1, mode: 'box', unit_of_measurement: '%'} } }
         ]
     }
 ];
@@ -151,7 +151,7 @@ export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEd
     
         newCustomPresets.push({
             icon: 'mdi:fan',
-            value: 100
+            percentage: 100
         })
 
         this._config!.custom_presets = newCustomPresets;
@@ -167,6 +167,8 @@ export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEd
         const index = (ev.currentTarget as any).index;
         const newCustomPresets = this._config!.custom_presets!.concat();
         newCustomPresets[index] = {...ev.detail.value};
+        if(!newCustomPresets[index].percentage)
+            newCustomPresets[index].percentage = 0;
         this._config!.custom_presets = newCustomPresets;
     
         fireEvent(this, "config-changed", { config: this._config! });

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -32,6 +32,7 @@ import { computeEntityPicture } from "../../utils/info";
 import { FAN_CARD_EDITOR_NAME, FAN_CARD_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import "./controls/fan-oscillate-control";
 import "./controls/fan-percentage-control";
+import "./controls/fan-preset-control";
 import { FanCardConfig } from "./fan-card-config";
 import { getPercentage } from "./utils";
 
@@ -135,7 +136,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
 
         const displayControls =
             (!this._config.collapsible_controls || isActive(entity)) &&
-            (this._config.show_percentage_control || this._config.show_oscillate_control);
+            (this._config.show_percentage_control || this._config.show_oscillate_control || this._config.presets);
 
         return html`
             <ha-card class=${classMap({ "fill-container": appearance.fill_container })}>
@@ -155,25 +156,41 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                     </mushroom-state-item>
                     ${displayControls
                         ? html`
-                              <div class="actions" ?rtl=${rtl}>
-                                  ${this._config.show_percentage_control
-                                      ? html`
-                                            <mushroom-fan-percentage-control
-                                                .hass=${this.hass}
-                                                .entity=${entity}
-                                                @current-change=${this.onCurrentPercentageChange}
-                                            ></mushroom-fan-percentage-control>
-                                        `
-                                      : null}
-                                  ${this._config.show_oscillate_control
-                                      ? html`
-                                            <mushroom-fan-oscillate-control
-                                                .hass=${this.hass}
-                                                .entity=${entity}
-                                            ></mushroom-fan-oscillate-control>
-                                        `
-                                      : null}
-                              </div>
+                              ${!!(this._config.show_percentage_control || this._config.show_oscillate_control) ? 
+                                html`
+                                    <div class="actions" ?rtl=${rtl}>
+                                    ${this._config.show_percentage_control
+                                        ? html`
+                                                <mushroom-fan-percentage-control
+                                                    .hass=${this.hass}
+                                                    .entity=${entity}
+                                                    @current-change=${this.onCurrentPercentageChange}
+                                                ></mushroom-fan-percentage-control>
+                                            `
+                                        : null}
+                                    ${this._config.show_oscillate_control
+                                        ? html`
+                                                <mushroom-fan-oscillate-control
+                                                    .hass=${this.hass}
+                                                    .entity=${entity}
+                                                ></mushroom-fan-oscillate-control>
+                                            `
+                                        : null}
+                                </div>
+                              `
+                              : null}
+                              ${this._config.presets ?
+                                html`
+                                <mushroom-fan-preset-control
+                                    class="actions"
+                                    ?rtl=${rtl}
+                                    .hass=${this.hass}
+                                    .entity=${entity}
+                                    .config=${this._config}
+                                    @current-change=${this.onCurrentPercentageChange}
+                                ></mushroom-fan-preset-control>
+                                `
+                                : null}
                           `
                         : null}
                 </mushroom-card>
@@ -226,6 +243,9 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                     color: red !important;
                 }
                 mushroom-fan-percentage-control {
+                    flex: 1;
+                }
+                mushroom-fan-preset-control {
                     flex: 1;
                 }
             `,

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -136,7 +136,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
 
         const displayControls =
             (!this._config.collapsible_controls || isActive(entity)) &&
-            (this._config.show_percentage_control || this._config.show_oscillate_control || this._config.presets);
+            (this._config.show_percentage_control || this._config.show_oscillate_control || this._config.custom_presets);
 
         return html`
             <ha-card class=${classMap({ "fill-container": appearance.fill_container })}>
@@ -174,7 +174,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                                                 ></mushroom-fan-oscillate-control>
                                             `
                                         : null}
-                                    ${this._config.presets 
+                                    ${this._config.custom_presets 
                                         ? html` 
                                             <mushroom-fan-preset-control
                                                 class="actions"

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -156,9 +156,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                     </mushroom-state-item>
                     ${displayControls
                         ? html`
-                              ${!!(this._config.show_percentage_control || this._config.show_oscillate_control) ? 
-                                html`
-                                    <div class="actions" ?rtl=${rtl}>
+                               <div class="actions" ?rtl=${rtl}>
                                     ${this._config.show_percentage_control
                                         ? html`
                                                 <mushroom-fan-percentage-control
@@ -176,22 +174,19 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                                                 ></mushroom-fan-oscillate-control>
                                             `
                                         : null}
+                                    ${this._config.presets 
+                                        ? html` 
+                                            <mushroom-fan-preset-control
+                                                class="actions"
+                                                ?rtl=${rtl}
+                                                .hass=${this.hass}
+                                                .entity=${entity}
+                                                .config=${this._config}
+                                                @current-change=${this.onCurrentPercentageChange}
+                                            ></mushroom-fan-preset-control>
+                                    ` : null}
                                 </div>
                               `
-                              : null}
-                              ${this._config.presets ?
-                                html`
-                                <mushroom-fan-preset-control
-                                    class="actions"
-                                    ?rtl=${rtl}
-                                    .hass=${this.hass}
-                                    .entity=${entity}
-                                    .config=${this._config}
-                                    @current-change=${this.onCurrentPercentageChange}
-                                ></mushroom-fan-preset-control>
-                                `
-                                : null}
-                          `
                         : null}
                 </mushroom-card>
             </ha-card>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -63,7 +63,12 @@
             },
             "fan": {
                 "show_percentage_control": "Percentage control?",
-                "show_oscillate_control": "Oscillate control?"
+                "show_oscillate_control": "Oscillate control?",
+                "custom_presets": {
+                    "title": "Custom Presets",
+                    "remove": "remove preset",
+                    "add": "add preset"
+                }
             },
             "cover": {
                 "show_buttons_control": "Control buttons?",


### PR DESCRIPTION
## Description

Added the ability to add a row of presets (instead of or in addition to slider)

![image](https://user-images.githubusercontent.com/342468/229977512-885a6fd9-b78f-4126-b22f-c177c161ef6a.png)
![image](https://user-images.githubusercontent.com/342468/229977499-9e0cfbe0-3f4c-4e35-9f65-a82d5c26037d.png)

A decision could be made if the buttons in default/vertical mode should be on their own line or not. I prefer them on their own line but I don't use a fan that has oscillate controls. Having the oscillate control on its own line when the slider is hidden has always looked odd to me, so it looks extra odd now. but not different than it already looks.

![image](https://user-images.githubusercontent.com/342468/229979057-6cb8ff7f-04d9-4302-8cd1-f69ad6e98949.png)
![image](https://user-images.githubusercontent.com/342468/229979102-88b01bec-bdf3-4354-b42b-733d09f03203.png)

Also note is that there doesn't seem to be any obvious way to do a "list" editor in the visual editor. home assistant has an entity-row editor but it seems purpose built not just generic for any scheme. Hopefully its not a deal braker that there's some optional yaml config, I realize that typically that isn't done here. I could write some custom editor I suppose.

## Related Issue

This PR closes issue: #888 part of #1032 and discussion #893

## Motivation and Context

Fan switches are often percentages in HA but in reality only honor a few values, and only a few values are usually valuable. Using a slider for a fan is awkward. Presets are reproducible especially on cheaper touchscreen devices.

## How Has This Been Tested

Running currently in my personal home assistant instance. Verified on ios 15, android with webview 110, chrome 111.0.5563.147 on windows 11.

## Types of changes

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [x] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language . (I didn't add a new  language)
