### PR TITLE
Gracefully handle not found entity states

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -55,9 +55,9 @@ export class SwitchCardEditor extends MushroomBaseElement implements LovelaceCar
         this._config = config;
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -112,9 +112,9 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
     async loadComponents() {
         if (!this._config || !this.hass || !this._config.entity) return;
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        if (hasCode(entity)) {
+        if (stateObj && hasCode(stateObj)) {
             void import("../../shared/form/mushroom-textfield");
         }
     }
@@ -147,8 +147,9 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
     private get _hasCode(): boolean {
         const entity_id = this._config?.entity;
         if (entity_id) {
-            const entity = this.hass.states[entity_id];
-            return hasCode(entity) && (this._config?.show_keypad ?? false);
+            const stateObj = this.hass.states[entity_id];
+            if (!stateObj) return false;
+            return hasCode(stateObj) && (this._config?.show_keypad ?? false);
         }
         return false;
     }
@@ -159,22 +160,25 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
         }
 
         const entity_id = this._config.entity;
+        const stateObj = this.hass.states[entity_id];
 
-        const entity = this.hass.states[entity_id];
+        if (!stateObj) {
+            return nothing;
+        }
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const actions: ActionButtonType[] =
             this._config.states && this._config.states.length > 0
-                ? isDisarmed(entity)
+                ? isDisarmed(stateObj)
                     ? this._config.states.map((state) => ({ state }))
                     : [{ state: "disarmed" }]
                 : [];
 
-        const isActionEnabled = isActionsAvailable(entity);
+        const isActionEnabled = isActionsAvailable(stateObj);
 
         const rtl = computeRTL(this.hass);
 
@@ -190,9 +194,9 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
                     ${actions.length > 0
                         ? html`
@@ -220,12 +224,12 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
                               id="alarmCode"
                               .label=${this.hass.localize("ui.card.alarm_control_panel.code")}
                               type="password"
-                              .inputmode=${entity.attributes.code_format === "number"
+                              .inputmode=${stateObj.attributes.code_format === "number"
                                   ? "numeric"
                                   : "text"}
                           ></mushroom-textfield>
                       `}
-                ${!(this._hasCode && entity.attributes.code_format === "number")
+                ${!(this._hasCode && stateObj.attributes.code_format === "number")
                     ? nothing
                     : html`
                           <div id="keypad">
@@ -255,9 +259,9 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
         `;
     }
 
-    protected renderIcon(entity: HassEntity, icon: string): TemplateResult {
-        const color = getStateColor(entity.state);
-        const shapePulse = shouldPulse(entity.state);
+    protected renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
+        const color = getStateColor(stateObj.state);
+        const shapePulse = shouldPulse(stateObj.state);
         const iconStyle = {
             "--icon-color": `rgb(${color})`,
             "--shape-color": `rgba(${color}, 0.2)`,

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -146,12 +146,10 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
 
     private get _hasCode(): boolean {
         const entity_id = this._config?.entity;
-        if (entity_id) {
-            const stateObj = this.hass.states[entity_id];
-            if (!stateObj) return false;
-            return hasCode(stateObj) && (this._config?.show_keypad ?? false);
-        }
-        return false;
+        if (!entity_id) return false;
+        const stateObj = this.hass.states[entity_id];
+        if (!stateObj) return false;
+        return hasCode(stateObj) && Boolean(this._config?.show_keypad);
     }
 
     protected render() {

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -111,8 +111,8 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
 
     async loadComponents() {
         if (!this._config || !this.hass || !this._config.entity) return;
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (stateObj && hasCode(stateObj)) {
             void import("../../shared/form/mushroom-textfield");
@@ -145,9 +145,9 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
     }
 
     private get _hasCode(): boolean {
-        const entity_id = this._config?.entity;
-        if (!entity_id) return false;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config?.entity;
+        if (!entityId) return false;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
         if (!stateObj) return false;
         return hasCode(stateObj) && Boolean(this._config?.show_keypad);
     }
@@ -157,11 +157,11 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -211,7 +211,7 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
                                   )}
                               </mushroom-button-group>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
                 ${!this._hasCode
                     ? nothing

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -7,7 +7,6 @@ import {
     actionHandler,
     ActionHandlerEvent,
     computeRTL,
-    computeStateDisplay,
     handleAction,
     hasAction,
     HomeAssistant,
@@ -27,7 +26,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { alarmPanelIconAction } from "../../utils/icons/alarm-panel-icon";
 import { stateIcon } from "../../utils/icons/state-icon";
-import { computeEntityPicture, computeInfoDisplay } from "../../utils/info";
+import { computeEntityPicture } from "../../utils/info";
 import { AlarmControlPanelCardConfig } from "./alarm-control-panel-card-config";
 import {
     ALARM_CONTROl_PANEL_CARD_EDITOR_NAME,
@@ -154,9 +153,9 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
         return false;
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -215,7 +214,7 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
                         : null}
                 </mushroom-card>
                 ${!this._hasCode
-                    ? html``
+                    ? nothing
                     : html`
                           <mushroom-textfield
                               id="alarmCode"
@@ -227,7 +226,7 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
                           ></mushroom-textfield>
                       `}
                 ${!(this._hasCode && entity.attributes.code_format === "number")
-                    ? html``
+                    ? nothing
                     : html`
                           <div id="keypad">
                               ${BUTTONS.map((value) =>

--- a/src/cards/alarm-control-panel-card/utils.ts
+++ b/src/cards/alarm-control-panel-card/utils.ts
@@ -21,14 +21,14 @@ export function shouldPulse(state: string): boolean {
     return ["arming", "triggered", "pending", UNAVAILABLE].indexOf(state) >= 0;
 }
 
-export function isActionsAvailable(entity: HassEntity) {
-    return UNAVAILABLE !== entity.state;
+export function isActionsAvailable(stateObj: HassEntity) {
+    return UNAVAILABLE !== stateObj.state;
 }
 
-export function isDisarmed(entity: HassEntity) {
-    return entity.state === "disarmed";
+export function isDisarmed(stateObj: HassEntity) {
+    return stateObj.state === "disarmed";
 }
 
-export function hasCode(entity: HassEntity): boolean {
-    return entity.attributes.code_format && entity.attributes.code_format !== "no_code";
+export function hasCode(stateObj: HassEntity): boolean {
+    return stateObj.attributes.code_format && stateObj.attributes.code_format !== "no_code";
 }

--- a/src/cards/chips-card/chips-card-chips-editor.ts
+++ b/src/cards/chips-card/chips-card-chips-editor.ts
@@ -269,9 +269,9 @@ export class ChipsCardEditorChips extends MushroomBaseElement {
 
     private getEntityName(entity_id: string): string | undefined {
         if (!this.hass) return undefined;
-        const entity = this.hass.states[entity_id];
-        if (!entity) return undefined;
-        return entity.attributes.friendly_name;
+        const stateObj = this.hass.states[entity_id];
+        if (!stateObj) return undefined;
+        return stateObj.attributes.friendly_name;
     }
 
     static get styles(): CSSResultGroup {

--- a/src/cards/chips-card/chips-card-chips-editor.ts
+++ b/src/cards/chips-card/chips-card-chips-editor.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { guard } from "lit/directives/guard.js";
 import type { SortableEvent } from "sortablejs";
@@ -44,9 +44,9 @@ export class ChipsCardEditorChips extends MushroomBaseElement {
         this._attached = false;
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.chips || !this.hass) {
-            return html``;
+            return nothing;
         }
 
         const customLocalize = setupCustomlocalize(this.hass);

--- a/src/cards/chips-card/chips-card-chips-editor.ts
+++ b/src/cards/chips-card/chips-card-chips-editor.ts
@@ -9,6 +9,7 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { getChipElementClass } from "../../utils/lovelace/chip-element-editor";
 import { CHIP_LIST, LovelaceChipConfig } from "../../utils/lovelace/chip/types";
 import { EditorTarget } from "../../utils/lovelace/editor/types";
+import { HassEntity } from "home-assistant-js-websocket";
 
 let Sortable;
 
@@ -269,7 +270,7 @@ export class ChipsCardEditorChips extends MushroomBaseElement {
 
     private getEntityName(entity_id: string): string | undefined {
         if (!this.hass) return undefined;
-        const stateObj = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id] as HassEntity | undefined;
         if (!stateObj) return undefined;
         return stateObj.attributes.friendly_name;
     }

--- a/src/cards/chips-card/chips-card-editor.ts
+++ b/src/cards/chips-card/chips-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import {
     any,
@@ -173,9 +173,9 @@ export class ChipsCardEditor extends MushroomBaseElement implements LovelaceCard
         return this._config!.theme || "";
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         if (this._subElementEditorConfig) {

--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import {
     computeRTL,
@@ -66,9 +66,9 @@ export class ChipsCard extends LitElement implements LovelaceCard {
         this._config = config;
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this._hass) {
-            return html``;
+            return nothing;
         }
 
         let alignment = "";
@@ -87,10 +87,10 @@ export class ChipsCard extends LitElement implements LovelaceCard {
         `;
     }
 
-    private renderChip(chipConfig: LovelaceChipConfig): TemplateResult {
+    private renderChip(chipConfig: LovelaceChipConfig) {
         const element = createChipElement(chipConfig);
         if (!element) {
-            return html``;
+            return nothing;
         }
         if (this._hass) {
             element.hass = this._hass;

--- a/src/cards/chips-card/chips/action-chip-editor.ts
+++ b/src/cards/chips-card/chips/action-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -45,9 +45,9 @@ export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this._config.icon || DEFAULT_ACTION_ICON;

--- a/src/cards/chips-card/chips/action-chip.ts
+++ b/src/cards/chips-card/chips/action-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import {
@@ -46,9 +46,9 @@ export class ActionChip extends LitElement implements LovelaceChip {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this._config.icon || DEFAULT_ACTION_ICON;

--- a/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -48,9 +48,9 @@ export class AlarmControlPanelChipEditor extends LitElement implements LovelaceC
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -66,16 +66,20 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
-        const iconColor = getStateColor(entity.state);
-        const iconPulse = shouldPulse(entity.state);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
+        const iconColor = getStateColor(stateObj.state);
+        const iconPulse = shouldPulse(stateObj.state);
 
         const stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
@@ -91,7 +95,7 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
             this._config.content_info ?? "state",
             name,
             stateDisplay,
-            entity,
+            stateObj,
             this.hass
         );
 

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -27,6 +27,7 @@ import {
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 import { ALARM_CONTROl_PANEL_ENTITY_DOMAINS } from "../../alarm-control-panel-card/const";
 import { getStateColor, shouldPulse } from "../../alarm-control-panel-card/utils";
+import { HassEntity } from "home-assistant-js-websocket";
 
 @customElement(computeChipComponentName("alarm-control-panel"))
 export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
@@ -65,8 +66,8 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
             return nothing;

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -60,9 +60,9 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -78,7 +78,7 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
 
         const iconStyle = {};

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -111,7 +111,7 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
                     style=${styleMap(iconStyle)}
                     class=${classMap({ pulse: iconPulse })}
                 ></ha-icon>
-                ${content ? html`<span>${content}</span>` : null}
+                ${content ? html`<span>${content}</span>` : nothing}
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/back-chip-editor.ts
+++ b/src/cards/chips-card/chips/back-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -26,9 +26,9 @@ export class BackChipEditor extends LitElement implements LovelaceChipEditor {
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this._config.icon || DEFAULT_BACK_ICON;

--- a/src/cards/chips-card/chips/back-chip.ts
+++ b/src/cards/chips-card/chips/back-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { actionHandler, computeRTL, HomeAssistant } from "../../../ha";
 import {
@@ -35,9 +35,9 @@ export class BackChip extends LitElement implements LovelaceChip {
         window.history.back();
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this._config.icon || DEFAULT_BACK_ICON;

--- a/src/cards/chips-card/chips/conditional-chip-editor.ts
+++ b/src/cards/chips-card/chips/conditional-chip-editor.ts
@@ -120,8 +120,9 @@ export class ConditionalChipEditor extends LitElement implements LovelaceChipEdi
                           ${this.hass!.localize(
                               "ui.panel.lovelace.editor.card.conditional.condition_explanation"
                           )}
-                          ${this._config.conditions.map(
-                              (cond, idx) => html`
+                          ${this._config.conditions.map((cond, idx) => {
+                              const stateObj = this.hass!.states[cond.entity];
+                              return html`
                                   <div class="condition" ?rtl=${rtl}>
                                       <div class="entity">
                                           <ha-entity-picker
@@ -157,11 +158,15 @@ export class ConditionalChipEditor extends LitElement implements LovelaceChipEdi
                                               </mwc-list-item>
                                           </mushroom-select>
                                           <mushroom-textfield
-                                              .label="${this.hass!.localize(
+                                              .label=${`${this.hass!.localize(
                                                   "ui.panel.lovelace.editor.card.generic.state"
-                                              )} (${this.hass!.localize(
-                                                  "ui.panel.lovelace.editor.card.conditional.current_state"
-                                              )}: ${this.hass?.states[cond.entity].state})"
+                                              )} ${
+                                                  stateObj
+                                                      ? `(${this.hass!.localize(
+                                                            "ui.panel.lovelace.editor.card.conditional.current_state"
+                                                        )}: ${stateObj.state})`
+                                                      : ""
+                                              }`}
                                               .value=${cond.state_not !== undefined
                                                   ? cond.state_not
                                                   : cond.state}
@@ -172,8 +177,8 @@ export class ConditionalChipEditor extends LitElement implements LovelaceChipEdi
                                           </mushroom-textfield>
                                       </div>
                                   </div>
-                              `
-                          )}
+                              `;
+                          })}
                           <div class="condition">
                               <ha-entity-picker
                                   .hass=${this.hass}

--- a/src/cards/chips-card/chips/conditional-chip-editor.ts
+++ b/src/cards/chips-card/chips/conditional-chip-editor.ts
@@ -1,5 +1,5 @@
 import type { MDCTabBarActivatedEvent } from "@material/tab-bar";
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { computeRTL, fireEvent, HASSDomEvent, HomeAssistant, LovelaceConfig } from "../../../ha";
 import setupCustomlocalize from "../../../localize";
@@ -41,9 +41,9 @@ export class ConditionalChipEditor extends LitElement implements LovelaceChipEdi
         this._cardEditorEl?.focusYamlEditor();
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const customLocalize = setupCustomlocalize(this.hass);

--- a/src/cards/chips-card/chips/entity-chip-editor.ts
+++ b/src/cards/chips-card/chips/entity-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -52,9 +52,9 @@ export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -103,8 +103,8 @@ export class EntityChip extends LitElement implements LovelaceChip {
                 .avatar=${picture ? (this.hass as any).hassUrl(picture) : undefined}
                 .avatarOnly=${picture && !content}
             >
-                ${!picture ? this.renderIcon(icon, iconColor, active) : null}
-                ${content ? html`<span>${content}</span>` : null}
+                ${!picture ? this.renderIcon(icon, iconColor, active) : nothing}
+                ${content ? html`<span>${content}</span>` : nothing}
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -52,9 +52,9 @@ export class EntityChip extends LitElement implements LovelaceChip {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -71,7 +71,7 @@ export class EntityChip extends LitElement implements LovelaceChip {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
 
         const active = isActive(entity);

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -22,6 +22,7 @@ import {
 } from "../../../utils/lovelace/chip/chip-element";
 import { EntityChipConfig, LovelaceChip } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
+import { HassEntity } from "home-assistant-js-websocket";
 
 @customElement(computeChipComponentName("entity"))
 export class EntityChip extends LitElement implements LovelaceChip {
@@ -57,8 +58,8 @@ export class EntityChip extends LitElement implements LovelaceChip {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
             return nothing;

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -58,23 +58,27 @@ export class EntityChip extends LitElement implements LovelaceChip {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const iconColor = this._config.icon_color;
 
-        const picture = this._config.use_entity_picture ? getEntityPicture(entity) : undefined;
+        const picture = this._config.use_entity_picture ? getEntityPicture(stateObj) : undefined;
 
         const stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
         );
 
-        const active = isActive(entity);
+        const active = isActive(stateObj);
 
         const iconStyle = {};
         if (iconColor) {
@@ -86,7 +90,7 @@ export class EntityChip extends LitElement implements LovelaceChip {
             this._config.content_info ?? "state",
             name,
             stateDisplay,
-            entity,
+            stateObj,
             this.hass
         );
 

--- a/src/cards/chips-card/chips/light-chip-editor.ts
+++ b/src/cards/chips-card/chips/light-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -56,9 +56,9 @@ export class LightChipEditor extends LitElement implements LovelaceChipEditor {
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -61,9 +61,9 @@ export class LightChip extends LitElement implements LovelaceChip {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -77,7 +77,7 @@ export class LightChip extends LitElement implements LovelaceChip {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
 
         const active = isActive(entity);

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -116,7 +116,7 @@ export class LightChip extends LitElement implements LovelaceChip {
                     style=${styleMap(iconStyle)}
                     class=${classMap({ active })}
                 ></ha-icon>
-                ${content ? html`<span>${content}</span>` : null}
+                ${content ? html`<span>${content}</span>` : nothing}
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -67,22 +67,26 @@ export class LightChip extends LitElement implements LovelaceChip {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as LightEntity;
+        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
 
         const stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
         );
 
-        const active = isActive(entity);
+        const active = isActive(stateObj);
 
-        const lightRgbColor = getRGBColor(entity);
+        const lightRgbColor = getRGBColor(stateObj);
         const iconStyle = {};
         if (lightRgbColor && this._config?.use_light_color) {
             const color = lightRgbColor.join(",");
@@ -96,7 +100,7 @@ export class LightChip extends LitElement implements LovelaceChip {
             this._config.content_info ?? "state",
             name,
             stateDisplay,
-            entity,
+            stateObj,
             this.hass
         );
 

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -66,8 +66,8 @@ export class LightChip extends LitElement implements LovelaceChip {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as LightEntity | undefined;
 
         if (!stateObj) {
             return nothing;

--- a/src/cards/chips-card/chips/menu-chip-editor.ts
+++ b/src/cards/chips-card/chips/menu-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -26,9 +26,9 @@ export class MenuChipEditor extends LitElement implements LovelaceChipEditor {
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this._config.icon || DEFAULT_MENU_ICON;

--- a/src/cards/chips-card/chips/menu-chip.ts
+++ b/src/cards/chips-card/chips/menu-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { actionHandler, computeRTL, fireEvent, HomeAssistant } from "../../../ha";
 import {
@@ -35,9 +35,9 @@ export class MenuChip extends LitElement implements LovelaceChip {
         fireEvent(this, "hass-toggle-menu" as any);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this._config.icon || DEFAULT_MENU_ICON;

--- a/src/cards/chips-card/chips/template-chip-editor.ts
+++ b/src/cards/chips-card/chips/template-chip-editor.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
@@ -59,9 +59,9 @@ export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const schema = computeSchema();

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -120,8 +120,8 @@ export class TemplateChip extends LitElement implements LovelaceChip {
                 .avatar=${picture ? (this.hass as any).hassUrl(picture) : undefined}
                 .avatarOnly=${picture && !content}
             >
-                ${icon && !picture ? this.renderIcon(icon, iconColor) : null}
-                ${content ? this.renderContent(content) : null}
+                ${icon && !picture ? this.renderIcon(icon, iconColor) : nothing}
+                ${content ? this.renderContent(content) : nothing}
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -1,5 +1,13 @@
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
+import {
+    css,
+    CSSResultGroup,
+    html,
+    LitElement,
+    nothing,
+    PropertyValues,
+    TemplateResult,
+} from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import {
@@ -89,9 +97,9 @@ export class TemplateChip extends LitElement implements LovelaceChip {
             : this._config?.[key];
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const icon = this.getValue("icon");

--- a/src/cards/chips-card/chips/weather-chip-editor.ts
+++ b/src/cards/chips-card/chips/weather-chip-editor.ts
@@ -1,5 +1,6 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
 import { fireEvent, HomeAssistant } from "../../../ha";
 import setupCustomlocalize from "../../../localize";
 import { computeActionsFormSchema } from "../../../shared/config/actions-config";
@@ -9,7 +10,6 @@ import { UiAction } from "../../../utils/form/ha-selector";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { WeatherChipConfig } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
-import memoizeOne from "memoize-one";
 
 const WEATHER_ENTITY_DOMAINS = ["weather"];
 const WEATHER_LABELS = ["show_conditions", "show_temperature"];
@@ -51,9 +51,9 @@ export class WeatherChipEditor extends LitElement implements LovelaceChipEditor 
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const schema = computeSchema();

--- a/src/cards/chips-card/chips/weather-chip.ts
+++ b/src/cards/chips-card/chips/weather-chip.ts
@@ -54,16 +54,20 @@ export class WeatherChip extends LitElement implements LovelaceChip {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const weatherIcon = getWeatherStateSVG(entity.state, true);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const weatherIcon = getWeatherStateSVG(stateObj.state, true);
 
         const displayLabels: string[] = [];
 
         if (this._config.show_conditions) {
             const stateDisplay = computeStateDisplay(
                 this.hass.localize,
-                entity,
+                stateObj,
                 this.hass.locale,
                 this.hass.entities,
                 this.hass.connection.haVersion
@@ -73,7 +77,7 @@ export class WeatherChip extends LitElement implements LovelaceChip {
 
         if (this._config.show_temperature) {
             const temperatureDisplay = `${formatNumber(
-                entity.attributes.temperature,
+                stateObj.attributes.temperature,
                 this.hass.locale
             )} ${this.hass.config.unit_system.temperature}`;
             displayLabels.push(temperatureDisplay);

--- a/src/cards/chips-card/chips/weather-chip.ts
+++ b/src/cards/chips-card/chips/weather-chip.ts
@@ -91,7 +91,9 @@ export class WeatherChip extends LitElement implements LovelaceChip {
                 })}
             >
                 ${weatherIcon}
-                ${displayLabels.length > 0 ? html`<span>${displayLabels.join(" / ")}</span>` : null}
+                ${displayLabels.length > 0
+                    ? html`<span>${displayLabels.join(" / ")}</span>`
+                    : nothing}
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/weather-chip.ts
+++ b/src/cards/chips-card/chips/weather-chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import {
     actionHandler,
@@ -48,9 +48,9 @@ export class WeatherChip extends LitElement implements LovelaceChip {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -66,7 +66,7 @@ export class WeatherChip extends LitElement implements LovelaceChip {
                 entity,
                 this.hass.locale,
                 this.hass.entities,
-                this.hass.connection.haVersion,
+                this.hass.connection.haVersion
             );
             displayLabels.push(stateDisplay);
         }

--- a/src/cards/chips-card/chips/weather-chip.ts
+++ b/src/cards/chips-card/chips/weather-chip.ts
@@ -17,6 +17,7 @@ import {
 import { LovelaceChip, WeatherChipConfig } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 import { getWeatherStateSVG, weatherSVGStyles } from "../../../utils/weather";
+import { HassEntity } from "home-assistant-js-websocket";
 
 @customElement(computeChipComponentName("weather"))
 export class WeatherChip extends LitElement implements LovelaceChip {
@@ -53,8 +54,8 @@ export class WeatherChip extends LitElement implements LovelaceChip {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
             return nothing;

--- a/src/cards/climate-card/climate-card-editor.ts
+++ b/src/cards/climate-card/climate-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -77,9 +77,9 @@ export class ClimateCardEditor extends MushroomBaseElement implements LovelaceCa
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -132,9 +132,9 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -150,7 +150,7 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
         if (entity.attributes.current_temperature !== null) {
             const temperature = formatNumber(

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -105,8 +105,8 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
     updateControls() {
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as ClimateEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as ClimateEntity | undefined;
 
         if (!stateObj) return;
 
@@ -136,11 +136,11 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as ClimateEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as ClimateEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -183,7 +183,7 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
                                   ${this.renderActiveControl(entity)}${this.renderOtherControls()}
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -30,7 +30,6 @@ import { cardStyle } from "../../utils/card-styles";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { computeEntityPicture } from "../../utils/info";
-import { Layout } from "../../utils/layout";
 import { ClimateCardConfig } from "./climate-card-config";
 import { CLIMATE_CARD_EDITOR_NAME, CLIMATE_CARD_NAME, CLIMATE_ENTITY_DOMAINS } from "./const";
 import "./controls/climate-hvac-modes-control";
@@ -218,12 +217,12 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
 
     renderActionBadge(entity: ClimateEntity) {
         const hvac_action = entity.attributes.hvac_action;
-        if (!hvac_action || hvac_action == "off") return null;
+        if (!hvac_action || hvac_action == "off") return nothing;
 
         const color = getHvacActionColor(hvac_action);
         const icon = getHvacActionIcon(hvac_action);
 
-        if (!icon) return null;
+        if (!icon) return nothing;
 
         return html`
             <mushroom-badge-icon
@@ -251,7 +250,7 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    private renderActiveControl(entity: ClimateEntity): TemplateResult | null {
+    private renderActiveControl(entity: ClimateEntity) {
         const hvac_modes = this._config!.hvac_modes ?? [];
         const appearance = computeAppearance(this._config!);
 
@@ -274,7 +273,7 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
                     ></mushroom-climate-hvac-modes-control>
                 `;
             default:
-                return null;
+                return nothing;
         }
     }
 

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -106,16 +106,16 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as ClimateEntity;
+        const stateObj = this.hass.states[entity_id] as ClimateEntity | undefined;
 
-        if (!entity) return;
+        if (!stateObj) return;
 
         const controls: ClimateCardControl[] = [];
-        if (!this._config.collapsible_controls || isActive(entity)) {
-            if (isTemperatureControlVisible(entity) && this._config.show_temperature_control) {
+        if (!this._config.collapsible_controls || isActive(stateObj)) {
+            if (isTemperatureControlVisible(stateObj) && this._config.show_temperature_control) {
                 controls.push("temperature_control");
             }
-            if (isHvacModesVisible(entity, this._config.hvac_modes)) {
+            if (isHvacModesVisible(stateObj, this._config.hvac_modes)) {
                 controls.push("hvac_mode_control");
             }
         }
@@ -137,23 +137,27 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as ClimateEntity;
+        const stateObj = this.hass.states[entity_id] as ClimateEntity | undefined;
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         let stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
         );
-        if (entity.attributes.current_temperature !== null) {
+        if (stateObj.attributes.current_temperature !== null) {
             const temperature = formatNumber(
-                entity.attributes.current_temperature,
+                stateObj.attributes.current_temperature,
                 this.hass.locale
             );
             const unit = this.hass.config.unit_system.temperature;
@@ -173,14 +177,14 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name, stateDisplay)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name, stateDisplay)};
                     </mushroom-state-item>
                     ${this._controls.length > 0
                         ? html`
                               <div class="actions" ?rtl=${rtl}>
-                                  ${this.renderActiveControl(entity)}${this.renderOtherControls()}
+                                  ${this.renderActiveControl(stateObj)}${this.renderOtherControls()}
                               </div>
                           `
                         : nothing}

--- a/src/cards/climate-card/controls/climate-temperature-control.ts
+++ b/src/cards/climate-card/controls/climate-temperature-control.ts
@@ -1,4 +1,4 @@
-import { html, LitElement, TemplateResult } from "lit";
+import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { styleMap } from "lit/directives/style-map.js";
 import { ClimateEntity, computeRTL, HomeAssistant, isAvailable, UNIT_F } from "../../../ha";
@@ -87,7 +87,7 @@ export class ClimateTemperatureControl extends LitElement {
                               @change=${this.onValueChange}
                           ></mushroom-input-number>
                       `
-                    : null}
+                    : nothing}
                 ${this.entity.attributes.target_temp_low != null &&
                 this.entity.attributes.target_temp_high != null
                     ? html`
@@ -114,7 +114,7 @@ export class ClimateTemperatureControl extends LitElement {
                               @change=${this.onHighValueChange}
                           ></mushroom-input-number>
                       `
-                    : null}
+                    : nothing}
             </mushroom-button-group>
         `;
     }

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -1,8 +1,8 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
-import { fireEvent, LovelaceCardEditor } from "../../ha";
+import { LovelaceCardEditor, fireEvent } from "../../ha";
 import setupCustomlocalize from "../../localize";
 import { computeActionsFormSchema } from "../../shared/config/actions-config";
 import { APPEARANCE_FORM_SCHEMA } from "../../shared/config/appearance-config";
@@ -63,9 +63,9 @@ export class CoverCardEditor extends MushroomBaseElement implements LovelaceCard
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -197,7 +197,7 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
                                   ${this.renderNextControlButton()}
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -220,8 +220,8 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    private renderNextControlButton(): TemplateResult | null {
-        if (!this._nextControl || this._nextControl == this._activeControl) return null;
+    private renderNextControlButton() {
+        if (!this._nextControl || this._nextControl == this._activeControl) return nothing;
 
         return html`
             <mushroom-button
@@ -231,7 +231,7 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    private renderActiveControl(entity: HassEntity, layout?: Layout): TemplateResult | null {
+    private renderActiveControl(entity: HassEntity, layout?: Layout) {
         switch (this._activeControl) {
             case "buttons_control":
                 return html`
@@ -271,7 +271,7 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
                 `;
             }
             default:
-                return null;
+                return nothing;
         }
     }
 

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -131,8 +131,8 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
         this.position = undefined;
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as CoverEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as CoverEntity | undefined;
 
         if (!stateObj) return;
         this.position = getPosition(stateObj);
@@ -153,11 +153,11 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as CoverEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as CoverEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -15,7 +15,7 @@ import {
     HomeAssistant,
     isAvailable,
     LovelaceCard,
-    LovelaceCardEditor
+    LovelaceCardEditor,
 } from "../../ha";
 import "../../shared/badge-icon";
 import "../../shared/button";
@@ -148,9 +148,9 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -166,7 +166,7 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
         if (this.position) {
             stateDisplay += ` - ${this.position}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -52,9 +52,9 @@ export class EntityCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -79,10 +79,10 @@ export class EntityCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entityId = this._config.entity;
-        const stateObj = this.hass.states[entityId];
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -79,13 +79,17 @@ export class EntityCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entityId = this._config.entity;
-        const entity = this.hass.states[entityId];
+        const stateObj = this.hass.states[entityId];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
 
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const rtl = computeRTL(this.hass);
 
@@ -101,17 +105,17 @@ export class EntityCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
                 </mushroom-card>
             </ha-card>
         `;
     }
 
-    renderIcon(entity: HassEntity, icon: string): TemplateResult {
-        const active = isActive(entity);
+    renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
+        const active = isActive(stateObj);
         const iconStyle = {};
         const iconColor = this._config?.icon_color;
         if (iconColor) {

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -73,9 +73,9 @@ export class EntityCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entityId = this._config.entity;

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -66,9 +66,9 @@ export class FanCardEditor extends MushroomBaseElement implements LovelaceCardEd
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -107,9 +107,9 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -125,7 +125,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
         if (this.percentage != null) {
             stateDisplay = `${this.percentage}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -91,10 +91,10 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        if (!entity) return;
-        this.percentage = getPercentage(entity);
+        if (!stateObj) return;
+        this.percentage = getPercentage(stateObj);
     }
 
     private onCurrentPercentageChange(e: CustomEvent<{ value?: number }>): void {
@@ -113,16 +113,20 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         let stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
@@ -134,7 +138,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         const displayControls =
-            (!this._config.collapsible_controls || isActive(entity)) &&
+            (!this._config.collapsible_controls || isActive(stateObj)) &&
             (this._config.show_percentage_control || this._config.show_oscillate_control);
 
         return html`
@@ -149,9 +153,9 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name, stateDisplay)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name, stateDisplay)};
                     </mushroom-state-item>
                     ${displayControls
                         ? html`
@@ -160,7 +164,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                                       ? html`
                                             <mushroom-fan-percentage-control
                                                 .hass=${this.hass}
-                                                .entity=${entity}
+                                                .entity=${stateObj}
                                                 @current-change=${this.onCurrentPercentageChange}
                                             ></mushroom-fan-percentage-control>
                                         `
@@ -169,7 +173,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                                       ? html`
                                             <mushroom-fan-oscillate-control
                                                 .hass=${this.hass}
-                                                .entity=${entity}
+                                                .entity=${stateObj}
                                             ></mushroom-fan-oscillate-control>
                                         `
                                       : nothing}
@@ -181,10 +185,10 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    protected renderIcon(entity: HassEntity, icon: string): TemplateResult {
+    protected renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
         let iconStyle = {};
-        const percentage = getPercentage(entity);
-        const active = isActive(entity);
+        const percentage = getPercentage(stateObj);
+        const active = isActive(stateObj);
         if (active) {
             if (percentage) {
                 const speed = 1.5 * (percentage / 100) ** 0.5;

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -90,8 +90,8 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
         this.percentage = undefined;
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) return;
         this.percentage = getPercentage(stateObj);
@@ -112,11 +112,11 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -164,7 +164,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                                                 @current-change=${this.onCurrentPercentageChange}
                                             ></mushroom-fan-percentage-control>
                                         `
-                                      : null}
+                                      : nothing}
                                   ${this._config.show_oscillate_control
                                       ? html`
                                             <mushroom-fan-oscillate-control
@@ -172,10 +172,10 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                                                 .entity=${entity}
                                             ></mushroom-fan-oscillate-control>
                                         `
-                                      : null}
+                                      : nothing}
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/fan-card/utils.ts
+++ b/src/cards/fan-card/utils.ts
@@ -1,18 +1,20 @@
 import { HassEntity } from "home-assistant-js-websocket";
 
-export function getPercentage(entity: HassEntity) {
-    return entity.attributes.percentage != null
-        ? Math.round(entity.attributes.percentage)
+export function getPercentage(stateObj: HassEntity) {
+    return stateObj.attributes.percentage != null
+        ? Math.round(stateObj.attributes.percentage)
         : undefined;
 }
 
-export function isOscillating(entity: HassEntity) {
-    return entity.attributes.oscillating != null ? Boolean(entity.attributes.oscillating) : false;
+export function isOscillating(stateObj: HassEntity) {
+    return stateObj.attributes.oscillating != null
+        ? Boolean(stateObj.attributes.oscillating)
+        : false;
 }
 
-export function computePercentageStep(entity: HassEntity) {
-    if (entity.attributes.percentage_step) {
-        return entity.attributes.percentage_step;
+export function computePercentageStep(stateObj: HassEntity) {
+    if (stateObj.attributes.percentage_step) {
+        return stateObj.attributes.percentage_step;
     }
     return 1;
 }

--- a/src/cards/humidifier-card/humidifier-card-editor.ts
+++ b/src/cards/humidifier-card/humidifier-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -58,9 +58,9 @@ export class HumidifierCardEditor extends MushroomBaseElement implements Lovelac
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/humidifier-card/humidifier-card.ts
+++ b/src/cards/humidifier-card/humidifier-card.ts
@@ -145,7 +145,7 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
                                   ></mushroom-humidifier-humidity-control>
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/humidifier-card/humidifier-card.ts
+++ b/src/cards/humidifier-card/humidifier-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import {
@@ -89,9 +89,9 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
         }
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -107,7 +107,7 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
         if (this.humidity) {
             stateDisplay = `${this.humidity}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/humidifier-card/humidifier-card.ts
+++ b/src/cards/humidifier-card/humidifier-card.ts
@@ -95,16 +95,20 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         let stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
@@ -116,7 +120,7 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
         const rtl = computeRTL(this.hass);
 
         const displayControls =
-            (!this._config.collapsible_controls || isActive(entity)) &&
+            (!this._config.collapsible_controls || isActive(stateObj)) &&
             this._config.show_target_humidity_control;
 
         return html`
@@ -131,16 +135,16 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name, stateDisplay)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name, stateDisplay)};
                     </mushroom-state-item>
                     ${displayControls
                         ? html`
                               <div class="actions" ?rtl=${rtl}>
                                   <mushroom-humidifier-humidity-control
                                       .hass=${this.hass}
-                                      .entity=${entity}
+                                      .entity=${stateObj}
                                       @current-change=${this.onCurrentHumidityChange}
                                   ></mushroom-humidifier-humidity-control>
                               </div>

--- a/src/cards/humidifier-card/humidifier-card.ts
+++ b/src/cards/humidifier-card/humidifier-card.ts
@@ -10,6 +10,7 @@ import {
     handleAction,
     hasAction,
     HomeAssistant,
+    HumidifierEntity,
     isActive,
     LovelaceCard,
     LovelaceCardEditor,
@@ -94,11 +95,11 @@ export class HumidifierCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HumidifierEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -1,8 +1,8 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
-import { fireEvent, LovelaceCardEditor } from "../../ha";
+import { LovelaceCardEditor, fireEvent } from "../../ha";
 import setupCustomlocalize from "../../localize";
 import { computeActionsFormSchema } from "../../shared/config/actions-config";
 import { APPEARANCE_FORM_SCHEMA } from "../../shared/config/appearance-config";
@@ -73,9 +73,9 @@ export class LightCardEditor extends MushroomBaseElement implements LovelaceCard
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -29,7 +29,7 @@ import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { stateIcon } from "../../utils/icons/state-icon";
-import { computeEntityPicture, computeInfoDisplay } from "../../utils/info";
+import { computeEntityPicture } from "../../utils/info";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_CARD_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
 import "./controls/light-brightness-control";
 import "./controls/light-color-control";
@@ -262,7 +262,7 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    private renderActiveControl(entity: LightEntity): TemplateResult | null {
+    private renderActiveControl(entity: LightEntity) {
         switch (this._activeControl) {
             case "brightness_control":
                 const lightRgbColor = getRGBColor(entity);
@@ -300,7 +300,7 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
                     <mushroom-light-color-control .hass=${this.hass} .entity=${entity} />
                 `;
             default:
-                return null;
+                return nothing;
         }
     }
 

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -211,7 +211,7 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
                                   ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -120,10 +120,10 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as LightEntity;
+        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
 
-        if (!entity) return;
-        this.brightness = getBrightness(entity);
+        if (!stateObj) return;
+        this.brightness = getBrightness(stateObj);
     }
 
     private onCurrentBrightnessChange(e: CustomEvent<{ value?: number }>): void {
@@ -136,19 +136,19 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as LightEntity;
+        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
 
-        if (!entity) return;
+        if (!stateObj) return;
 
         const controls: LightCardControl[] = [];
-        if (!this._config.collapsible_controls || isActive(entity)) {
-            if (this._config.show_brightness_control && supportsBrightnessControl(entity)) {
+        if (!this._config.collapsible_controls || isActive(stateObj)) {
+            if (this._config.show_brightness_control && supportsBrightnessControl(stateObj)) {
                 controls.push("brightness_control");
             }
-            if (this._config.show_color_temp_control && supportsColorTempControl(entity)) {
+            if (this._config.show_color_temp_control && supportsColorTempControl(stateObj)) {
                 controls.push("color_temp_control");
             }
-            if (this._config.show_color_control && supportsColorControl(entity)) {
+            if (this._config.show_color_control && supportsColorControl(stateObj)) {
                 controls.push("color_control");
             }
         }
@@ -169,16 +169,20 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as LightEntity;
+        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         let stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
@@ -201,14 +205,15 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name, stateDisplay)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name, stateDisplay)};
                     </mushroom-state-item>
                     ${this._controls.length > 0
                         ? html`
                               <div class="actions" ?rtl=${rtl}>
-                                  ${this.renderActiveControl(entity)} ${this.renderOtherControls()}
+                                  ${this.renderActiveControl(stateObj)}
+                                  ${this.renderOtherControls()}
                               </div>
                           `
                         : nothing}

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -163,9 +163,9 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -181,7 +181,7 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
         if (this.brightness != null) {
             stateDisplay = `${this.brightness}${blankBeforePercent(this.hass.locale)}%`;

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -119,8 +119,8 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         this.brightness = undefined;
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as LightEntity | undefined;
 
         if (!stateObj) return;
         this.brightness = getBrightness(stateObj);
@@ -135,8 +135,8 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
     updateControls() {
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as LightEntity | undefined;
 
         if (!stateObj) return;
 
@@ -168,11 +168,11 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as LightEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as LightEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/lock-card/lock-card-editor.ts
+++ b/src/cards/lock-card/lock-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -45,9 +45,9 @@ export class LockCardEditor extends MushroomBaseElement implements LovelaceCardE
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -81,12 +81,16 @@ export class LockCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entityId = this._config.entity;
-        const entity = this.hass.states[entityId] as LockEntity;
+        const stateObj = this.hass.states[entityId] as LockEntity | undefined;
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return this.renderNotFound(this._config);
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const rtl = computeRTL(this.hass);
 
@@ -102,14 +106,16 @@ export class LockCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture
+                            ? this.renderPicture(picture)
+                            : this.renderIcon(stateObj as LockEntity, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
                     <div class="actions" ?rtl=${rtl}>
                         <mushroom-lock-buttons-control
                             .hass=${this.hass}
-                            .entity=${entity}
+                            .entity=${stateObj}
                             .fill=${appearance.layout !== "horizontal"}
                         >
                         </mushroom-lock-buttons-control>

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -75,9 +75,9 @@ export class LockCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entityId = this._config.entity;

--- a/src/cards/media-player-card/controls/media-player-volume-control.ts
+++ b/src/cards/media-player-card/controls/media-player-volume-control.ts
@@ -92,7 +92,7 @@ export class MediaPlayerVolumeControls extends LitElement {
                           @change=${this.handleSliderChange}
                           @current-change=${this.handleSliderCurrentChange}
                       />`
-                    : null}
+                    : nothing}
                 ${displayVolumeMute
                     ? html`
                           <mushroom-button

--- a/src/cards/media-player-card/controls/media-player-volume-control.ts
+++ b/src/cards/media-player-card/controls/media-player-volume-control.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import {
     computeRTL,
@@ -6,10 +6,10 @@ import {
     isActive,
     isAvailable,
     isOff,
-    MediaPlayerEntity,
     MEDIA_PLAYER_SUPPORT_VOLUME_BUTTONS,
     MEDIA_PLAYER_SUPPORT_VOLUME_MUTE,
     MEDIA_PLAYER_SUPPORT_VOLUME_SET,
+    MediaPlayerEntity,
     supportsFeature,
 } from "../../../ha";
 import { MediaPlayerVolumeControl } from "../media-player-card-config";
@@ -60,8 +60,8 @@ export class MediaPlayerVolumeControls extends LitElement {
         handleMediaControlClick(this.hass, this.entity, action!);
     }
 
-    protected render(): TemplateResult | null {
-        if (!this.entity) return null;
+    protected render() {
+        if (!this.entity) return nothing;
 
         const value = getVolumeLevel(this.entity);
 

--- a/src/cards/media-player-card/media-player-card-editor.ts
+++ b/src/cards/media-player-card/media-player-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -106,9 +106,9 @@ export class MediaCardEditor extends MushroomBaseElement implements LovelaceCard
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import {
@@ -159,9 +159,9 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -116,8 +116,8 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
         this.volume = undefined;
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as MediaPlayerEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as MediaPlayerEntity | undefined;
 
         if (!stateObj) return;
         const volume = getVolumeLevel(stateObj);
@@ -133,8 +133,8 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
     updateControls() {
         if (!this._config || !this.hass || !this._config.entity) return;
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as MediaPlayerEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as MediaPlayerEntity | undefined;
 
         if (!stateObj) return;
 
@@ -164,11 +164,11 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as MediaPlayerEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as MediaPlayerEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const icon = computeMediaIcon(this._config, stateObj);

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -224,7 +224,7 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    private renderActiveControl(entity: MediaPlayerEntity, layout: Layout): TemplateResult | null {
+    private renderActiveControl(entity: MediaPlayerEntity, layout: Layout) {
         const media_controls = this._config?.media_controls ?? [];
         const volume_controls = this._config?.volume_controls ?? [];
 
@@ -250,7 +250,7 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
                     />
                 `;
             default:
-                return null;
+                return nothing;
         }
     }
 

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -203,7 +203,7 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
                                   ${this.renderOtherControls()}
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -117,10 +117,10 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as MediaPlayerEntity;
+        const stateObj = this.hass.states[entity_id] as MediaPlayerEntity | undefined;
 
-        if (!entity) return;
-        const volume = getVolumeLevel(entity);
+        if (!stateObj) return;
+        const volume = getVolumeLevel(stateObj);
         this.volume = volume != null ? Math.round(volume) : volume;
     }
 
@@ -134,16 +134,16 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
         if (!this._config || !this.hass || !this._config.entity) return;
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as MediaPlayerEntity;
+        const stateObj = this.hass.states[entity_id] as MediaPlayerEntity | undefined;
 
-        if (!entity) return;
+        if (!stateObj) return;
 
         const controls: MediaPlayerCardControl[] = [];
-        if (!this._config.collapsible_controls || isActive(entity)) {
-            if (isMediaControlVisible(entity, this._config?.media_controls)) {
+        if (!this._config.collapsible_controls || isActive(stateObj)) {
+            if (isMediaControlVisible(stateObj, this._config?.media_controls)) {
                 controls.push("media_control");
             }
-            if (isVolumeControlVisible(entity, this._config.volume_controls)) {
+            if (isVolumeControlVisible(stateObj, this._config.volume_controls)) {
                 controls.push("volume_control");
             }
         }
@@ -165,13 +165,17 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as MediaPlayerEntity;
+        const stateObj = this.hass.states[entity_id] as MediaPlayerEntity | undefined;
 
-        const icon = computeMediaIcon(this._config, entity);
-        const nameDisplay = computeMediaNameDisplay(this._config, entity);
-        const stateDisplay = computeMediaStateDisplay(this._config, entity, this.hass);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const icon = computeMediaIcon(this._config, stateObj);
+        const nameDisplay = computeMediaNameDisplay(this._config, stateObj);
+        const stateDisplay = computeMediaStateDisplay(this._config, stateObj, this.hass);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const stateValue =
             this.volume != null && this._config.show_volume_level
@@ -192,14 +196,14 @@ export class MediaPlayerCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, nameDisplay, stateValue)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, nameDisplay, stateValue)};
                     </mushroom-state-item>
                     ${this._controls.length > 0
                         ? html`
                               <div class="actions" ?rtl=${rtl}>
-                                  ${this.renderActiveControl(entity, appearance.layout)}
+                                  ${this.renderActiveControl(stateObj, appearance.layout)}
                                   ${this.renderOtherControls()}
                               </div>
                           `

--- a/src/cards/media-player-card/utils.ts
+++ b/src/cards/media-player-card/utils.ts
@@ -24,12 +24,12 @@ import { MediaPlayerCardConfig, MediaPlayerMediaControl } from "./media-player-c
 export function callService(
     e: MouseEvent,
     hass: HomeAssistant,
-    entity: HassEntity,
+    stateObj: HassEntity,
     serviceName: string
 ): void {
     e.stopPropagation();
     hass.callService("media_player", serviceName, {
-        entity_id: entity.entity_id,
+        entity_id: stateObj.entity_id,
     });
 }
 

--- a/src/cards/number-card/number-card-editor.ts
+++ b/src/cards/number-card/number-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -71,9 +71,9 @@ export class NumberCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/number-card/number-card.ts
+++ b/src/cards/number-card/number-card.ts
@@ -94,16 +94,20 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         let stateDisplay = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
@@ -112,10 +116,10 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
             const numberValue = formatNumber(
                 this.value,
                 this.hass.locale,
-                getNumberFormatOptions(entity, this.hass.entities[entity.entity_id]) ??
-                    getDefaultFormatOptions(entity.state)
+                getNumberFormatOptions(stateObj, this.hass.entities[stateObj.entity_id]) ??
+                    getDefaultFormatOptions(stateObj.state)
             );
-            stateDisplay = `${numberValue} ${entity.attributes.unit_of_measurement ?? ""}`;
+            stateDisplay = `${numberValue} ${stateObj.attributes.unit_of_measurement ?? ""}`;
         }
 
         const rtl = computeRTL(this.hass);
@@ -140,14 +144,14 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name, stateDisplay)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name, stateDisplay)};
                     </mushroom-state-item>
                     <div class="actions" ?rtl=${rtl}>
                         <mushroom-number-value-control
                             .hass=${this.hass}
-                            .entity=${entity}
+                            .entity=${stateObj}
                             .displayMode=${this._config.display_mode}
                             style=${styleMap(sliderStyle)}
                             @current-change=${this.onCurrentValueChange}
@@ -158,8 +162,8 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    renderIcon(entity: HassEntity, icon: string): TemplateResult {
-        const active = isActive(entity);
+    renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
+        const active = isActive(stateObj);
         const iconStyle = {};
         const iconColor = this._config?.icon_color;
         if (iconColor) {

--- a/src/cards/number-card/number-card.ts
+++ b/src/cards/number-card/number-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -88,9 +88,9 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
         }
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;
@@ -106,7 +106,7 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
             entity,
             this.hass.locale,
             this.hass.entities,
-            this.hass.connection.haVersion,
+            this.hass.connection.haVersion
         );
         if (this.value !== undefined) {
             const numberValue = formatNumber(

--- a/src/cards/number-card/number-card.ts
+++ b/src/cards/number-card/number-card.ts
@@ -93,11 +93,11 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -48,9 +48,9 @@ export class SwitchCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -74,9 +74,9 @@ export class PersonCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -80,12 +80,16 @@ export class PersonCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id];
+        const stateObj = this.hass.states[entity_id];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const rtl = computeRTL(this.hass);
 
@@ -101,21 +105,21 @@ export class PersonCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
                 </mushroom-card>
             </ha-card>
         `;
     }
 
-    renderStateBadge(entity: HassEntity) {
-        const zones = Object.values(this.hass.states).filter((entity) =>
-            entity.entity_id.startsWith("zone.")
+    renderStateBadge(stateObj: HassEntity) {
+        const zones = Object.values(this.hass.states).filter((stateObj) =>
+            stateObj.entity_id.startsWith("zone.")
         );
-        const icon = getStateIcon(entity, zones);
-        const color = getStateColor(entity, zones);
+        const icon = getStateIcon(stateObj, zones);
+        const color = getStateColor(stateObj, zones);
 
         return html`
             <mushroom-badge-icon
@@ -128,12 +132,12 @@ export class PersonCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    renderBadge(entity: HassEntity) {
-        const unavailable = !isAvailable(entity);
+    renderBadge(stateObj: HassEntity) {
+        const unavailable = !isAvailable(stateObj);
         if (unavailable) {
-            return super.renderBadge(entity);
+            return super.renderBadge(stateObj);
         } else {
-            return this.renderStateBadge(entity);
+            return this.renderStateBadge(stateObj);
         }
     }
 

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -79,11 +79,11 @@ export class PersonCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id];
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/person-card/utils.ts
+++ b/src/cards/person-card/utils.ts
@@ -1,8 +1,8 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { UNKNOWN } from "../../ha";
 
-export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
-    const state = entity.state;
+export function getStateIcon(stateObj: HassEntity, zones: HassEntity[]) {
+    const state = stateObj.state;
     if (state === UNKNOWN) {
         return "mdi:help";
     } else if (state === "not_home") {
@@ -19,8 +19,8 @@ export function getStateIcon(entity: HassEntity, zones: HassEntity[]) {
     return "mdi:home";
 }
 
-export function getStateColor(entity: HassEntity, zones: HassEntity[]) {
-    const state = entity.state;
+export function getStateColor(stateObj: HassEntity, zones: HassEntity[]) {
+    const state = stateObj.state;
     if (state === UNKNOWN) {
         return "var(--rgb-state-person-unknown)";
     } else if (state === "not_home") {

--- a/src/cards/select-card/controls/select-option-control.ts
+++ b/src/cards/select-card/controls/select-option-control.ts
@@ -22,8 +22,8 @@ export class SelectOptionControl extends LitElement {
     }
 
     _setValue(option) {
-        const entity_id = this.entity.entity_id;
-        const domain = entity_id.split(".")[0];
+        const entityId = this.entity.entity_id;
+        const domain = entityId.split(".")[0];
 
         this.hass.callService(domain, "select_option", {
             entity_id: this.entity.entity_id,

--- a/src/cards/select-card/select-card-editor.ts
+++ b/src/cards/select-card/select-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -55,9 +55,9 @@ export class SelectCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/select-card/select-card.ts
+++ b/src/cards/select-card/select-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -75,9 +75,9 @@ export class SelectCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entityId = this._config.entity;

--- a/src/cards/select-card/select-card.ts
+++ b/src/cards/select-card/select-card.ts
@@ -81,13 +81,17 @@ export class SelectCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entityId = this._config.entity;
-        const entity = this.hass.states[entityId];
+        const stateObj = this.hass.states[entityId];
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
 
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const rtl = computeRTL(this.hass);
         const iconColor = this._config?.icon_color;
@@ -110,15 +114,15 @@ export class SelectCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
                     <div class="actions" ?rtl=${rtl}>
                         <mushroom-select-option-control
                             style=${styleMap(selectStyle)}
                             .hass=${this.hass}
-                            .entity=${entity}
+                            .entity=${stateObj}
                         ></mushroom-select-option-control>
                     </div>
                 </mushroom-card>
@@ -126,8 +130,8 @@ export class SelectCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    renderIcon(entity: HassEntity, icon: string): TemplateResult {
-        const active = isActive(entity);
+    renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
+        const active = isActive(stateObj);
         const iconStyle = {};
         const iconColor = this._config?.icon_color;
         if (iconColor) {

--- a/src/cards/select-card/select-card.ts
+++ b/src/cards/select-card/select-card.ts
@@ -81,10 +81,10 @@ export class SelectCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entityId = this._config.entity;
-        const stateObj = this.hass.states[entityId];
+        const stateObj = this.hass.states[entityId] as HassEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/select-card/utils.ts
+++ b/src/cards/select-card/utils.ts
@@ -1,9 +1,9 @@
 import { HassEntity } from "home-assistant-js-websocket";
 
-export function getCurrentOption(entity: HassEntity) {
-    return entity.state != null ? entity.state : undefined;
+export function getCurrentOption(stateObj: HassEntity) {
+    return stateObj.state != null ? stateObj.state : undefined;
 }
 
-export function getOptions(entity: HassEntity) {
-    return entity.attributes.options;
+export function getOptions(stateObj: HassEntity) {
+    return stateObj.attributes.options;
 }

--- a/src/cards/template-card/template-card-editor.ts
+++ b/src/cards/template-card/template-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -95,9 +95,9 @@ export class TemplateCardEditor extends MushroomBaseElement implements LovelaceC
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const schema = computeSchema();

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -153,7 +153,7 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
                             ? this.renderPicture(picture)
                             : icon
                             ? this.renderIcon(icon, iconColor)
-                            : null}
+                            : nothing}
                         ${(icon || picture) && badgeIcon
                             ? this.renderBadgeIcon(badgeIcon, badgeColor)
                             : undefined}

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -1,5 +1,5 @@
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -112,9 +112,9 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
             : this._config?.[key];
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass) {
-            return html``;
+            return nothing;
         }
 
         const icon = this.getValue("icon");

--- a/src/cards/title-card/title-card-editor.ts
+++ b/src/cards/title-card/title-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -57,9 +57,9 @@ export class TitleCardEditor extends MushroomBaseElement implements LovelaceCard
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const schema = computeSchema();

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -1,5 +1,5 @@
 import { UnsubscribeFunc } from "home-assistant-js-websocket";
-import { css, CSSResultGroup, html, PropertyValues, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, PropertyValues } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { ifDefined } from "lit/directives/if-defined.js";
@@ -109,9 +109,9 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
         handleAction(this, this.hass!, config, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass) {
-            return html``;
+            return nothing;
         }
 
         const title = this.getValue("title");

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -146,7 +146,7 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
                               <h1 class="title">${title}${this.renderArrow()}</h1>
                           </div>
                       `
-                    : null}
+                    : nothing}
                 ${subtitle
                     ? html`
                           <div
@@ -161,7 +161,7 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
                               <h2 class="subtitle">${subtitle}${this.renderArrow()}</h2>
                           </div>
                       `
-                    : null}
+                    : nothing}
             </div>
         `;
     }

--- a/src/cards/update-card/update-card-editor.ts
+++ b/src/cards/update-card/update-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -61,9 +61,9 @@ export class UpdateCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -124,7 +124,7 @@ export class UpdateCard extends MushroomBaseCard implements LovelaceCard {
                                   ></mushroom-update-buttons-control>
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -84,19 +84,23 @@ export class UpdateCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entityId = this._config.entity;
-        const entity = this.hass.states[entityId] as UpdateEntity;
+        const stateObj = this.hass.states[entityId] as UpdateEntity | undefined;
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return this.renderNotFound(this._config);
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const rtl = computeRTL(this.hass);
 
         const displayControls =
-            (!this._config.collapsible_controls || isActive(entity)) &&
+            (!this._config.collapsible_controls || isActive(stateObj)) &&
             this._config.show_buttons_control &&
-            supportsFeature(entity, UPDATE_SUPPORT_INSTALL);
+            supportsFeature(stateObj, UPDATE_SUPPORT_INSTALL);
 
         return html`
             <ha-card class=${classMap({ "fill-container": appearance.fill_container })}>
@@ -110,16 +114,16 @@ export class UpdateCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
                     ${displayControls
                         ? html`
                               <div class="actions" ?rtl=${rtl}>
                                   <mushroom-update-buttons-control
                                       .hass=${this.hass}
-                                      .entity=${entity}
+                                      .entity=${stateObj}
                                       .fill=${appearance.layout !== "horizontal"}
                                   ></mushroom-update-buttons-control>
                               </div>

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -14,9 +14,9 @@ import {
     LovelaceCard,
     LovelaceCardEditor,
     supportsFeature,
+    UPDATE_SUPPORT_INSTALL,
     UpdateEntity,
     updateIsInstalling,
-    UPDATE_SUPPORT_INSTALL,
 } from "../../ha";
 import "../../shared/badge-icon";
 import "../../shared/card";
@@ -78,9 +78,9 @@ export class UpdateCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entityId = this._config.entity;

--- a/src/cards/vacuum-card/utils.ts
+++ b/src/cards/vacuum-card/utils.ts
@@ -8,8 +8,8 @@ import {
     STATE_RETURNING,
 } from "../../ha";
 
-export function isCleaning(entity: HassEntity): boolean {
-    switch (entity.state) {
+export function isCleaning(stateObj: HassEntity): boolean {
+    switch (stateObj.state) {
         case STATE_CLEANING:
         case STATE_ON:
             return true;
@@ -18,8 +18,8 @@ export function isCleaning(entity: HassEntity): boolean {
     }
 }
 
-export function isStopped(entity: HassEntity): boolean {
-    switch (entity.state) {
+export function isStopped(stateObj: HassEntity): boolean {
+    switch (stateObj.state) {
         case STATE_DOCKED:
         case STATE_OFF:
         case STATE_IDLE:
@@ -30,8 +30,8 @@ export function isStopped(entity: HassEntity): boolean {
     }
 }
 
-export function isReturningHome(entity: HassEntity): boolean {
-    switch (entity.state) {
+export function isReturningHome(stateObj: HassEntity): boolean {
+    switch (stateObj.state) {
         case STATE_RETURNING:
             return true;
         default:

--- a/src/cards/vacuum-card/vacuum-card-editor.ts
+++ b/src/cards/vacuum-card/vacuum-card-editor.ts
@@ -1,4 +1,4 @@
-import { html, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import memoizeOne from "memoize-one";
 import { assert } from "superstruct";
@@ -12,7 +12,7 @@ import { HaFormSchema } from "../../utils/form/ha-form";
 import { stateIcon } from "../../utils/icons/state-icon";
 import { loadHaComponents } from "../../utils/loader";
 import { VACUUM_CARD_EDITOR_NAME, VACUUM_ENTITY_DOMAINS } from "./const";
-import { VacuumCardConfig, vacuumCardConfigStruct, VACUUM_COMMANDS } from "./vacuum-card-config";
+import { VACUUM_COMMANDS, VacuumCardConfig, vacuumCardConfigStruct } from "./vacuum-card-config";
 
 const VACUUM_LABELS = ["commands"];
 
@@ -75,9 +75,9 @@ export class VacuumCardEditor extends MushroomBaseElement implements LovelaceCar
         return this.hass!.localize(`ui.panel.lovelace.editor.card.generic.${schema.name}`);
     };
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this.hass || !this._config) {
-            return html``;
+            return nothing;
         }
 
         const entityState = this._config.entity ? this.hass.states[this._config.entity] : undefined;

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -82,12 +82,16 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
         }
 
         const entity_id = this._config.entity;
-        const entity = this.hass.states[entity_id] as VacuumEntity;
+        const stateObj = this.hass.states[entity_id] as VacuumEntity | undefined;
 
-        const name = this._config.name || entity.attributes.friendly_name || "";
-        const icon = this._config.icon || stateIcon(entity);
+        if (!stateObj) {
+            return nothing;
+        }
+
+        const name = this._config.name || stateObj.attributes.friendly_name || "";
+        const icon = this._config.icon || stateIcon(stateObj);
         const appearance = computeAppearance(this._config);
-        const picture = computeEntityPicture(entity, appearance.icon_type);
+        const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
         const rtl = computeRTL(this.hass);
 
@@ -105,16 +109,16 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
                             hasDoubleClick: hasAction(this._config.double_tap_action),
                         })}
                     >
-                        ${picture ? this.renderPicture(picture) : this.renderIcon(entity, icon)}
-                        ${this.renderBadge(entity)}
-                        ${this.renderStateInfo(entity, appearance, name)};
+                        ${picture ? this.renderPicture(picture) : this.renderIcon(stateObj, icon)}
+                        ${this.renderBadge(stateObj)}
+                        ${this.renderStateInfo(stateObj, appearance, name)};
                     </mushroom-state-item>
-                    ${isCommandsControlVisible(entity, commands)
+                    ${isCommandsControlVisible(stateObj, commands)
                         ? html`
                               <div class="actions" ?rtl=${rtl}>
                                   <mushroom-vacuum-commands-control
                                       .hass=${this.hass}
-                                      .entity=${entity}
+                                      .entity=${stateObj}
                                       .commands=${commands}
                                       .fill=${appearance.layout !== "horizontal"}
                                   >
@@ -127,16 +131,16 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
         `;
     }
 
-    protected renderIcon(entity: HassEntity, icon: string): TemplateResult {
+    protected renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
         return html`
             <mushroom-shape-icon
                 slot="icon"
                 class=${classMap({
-                    returning: isReturningHome(entity) && Boolean(this._config?.icon_animation),
-                    cleaning: isCleaning(entity) && Boolean(this._config?.icon_animation),
+                    returning: isReturningHome(stateObj) && Boolean(this._config?.icon_animation),
+                    cleaning: isCleaning(stateObj) && Boolean(this._config?.icon_animation),
                 })}
                 style=${styleMap({})}
-                .disabled=${!isActive(entity)}
+                .disabled=${!isActive(stateObj)}
                 .icon=${icon}
             ></mushroom-shape-icon>
         `;

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -1,18 +1,19 @@
-import { css, CSSResultGroup, html, TemplateResult } from "lit";
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
 import {
-    ActionHandlerEvent,
-    HomeAssistant,
-    LovelaceCard,
-    LovelaceCardEditor,
-    VacuumEntity,
     actionHandler,
+    ActionHandlerEvent,
     computeRTL,
     handleAction,
     hasAction,
+    HomeAssistant,
     isActive,
+    LovelaceCard,
+    LovelaceCardEditor,
+    VacuumEntity,
 } from "../../ha";
 import "../../shared/badge-icon";
 import "../../shared/card";
@@ -28,9 +29,8 @@ import { computeEntityPicture } from "../../utils/info";
 import { VACUUM_CARD_EDITOR_NAME, VACUUM_CARD_NAME, VACUUM_ENTITY_DOMAINS } from "./const";
 import "./controls/vacuum-commands-control";
 import { isCommandsControlVisible } from "./controls/vacuum-commands-control";
-import { VacuumCardConfig } from "./vacuum-card-config";
-import { HassEntity } from "home-assistant-js-websocket";
 import { isCleaning, isReturningHome } from "./utils";
+import { VacuumCardConfig } from "./vacuum-card-config";
 
 registerCustomCard({
     type: VACUUM_CARD_NAME,
@@ -76,9 +76,9 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
         handleAction(this, this.hass!, this._config!, ev.detail.action!);
     }
 
-    protected render(): TemplateResult {
+    protected render() {
         if (!this._config || !this.hass || !this._config.entity) {
-            return html``;
+            return nothing;
         }
 
         const entity_id = this._config.entity;

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -81,11 +81,11 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
             return nothing;
         }
 
-        const entity_id = this._config.entity;
-        const stateObj = this.hass.states[entity_id] as VacuumEntity | undefined;
+        const entityId = this._config.entity;
+        const stateObj = this.hass.states[entityId] as VacuumEntity | undefined;
 
         if (!stateObj) {
-            return nothing;
+            return this.renderNotFound(this._config);
         }
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -121,7 +121,7 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
                                   </mushroom-vacuum-commands-control>
                               </div>
                           `
-                        : null}
+                        : nothing}
                 </mushroom-card>
             </ha-card>
         `;

--- a/src/ha/data/entity.ts
+++ b/src/ha/data/entity.ts
@@ -9,9 +9,9 @@ export const OFF = "off";
 
 const OFF_STATES = [UNAVAILABLE, UNKNOWN, OFF];
 
-export function isActive(entity: HassEntity) {
-    const domain = computeDomain(entity.entity_id);
-    const state = entity.state;
+export function isActive(stateObj: HassEntity) {
+    const domain = computeDomain(stateObj.entity_id);
+    const state = stateObj.state;
 
     if (["button", "input_button", "scene"].includes(domain)) {
         return state !== UNAVAILABLE;
@@ -39,21 +39,21 @@ export function isActive(entity: HassEntity) {
     }
 }
 
-export function isAvailable(entity: HassEntity) {
-    return entity.state !== UNAVAILABLE;
+export function isAvailable(stateObj: HassEntity) {
+    return stateObj.state !== UNAVAILABLE;
 }
 
-export function isOff(entity: HassEntity) {
-    return entity.state === OFF;
+export function isOff(stateObj: HassEntity) {
+    return stateObj.state === OFF;
 }
 
-export function isUnknown(entity: HassEntity) {
-    return entity.state === UNKNOWN;
+export function isUnknown(stateObj: HassEntity) {
+    return stateObj.state === UNKNOWN;
 }
 
-export function getEntityPicture(entity: HassEntity) {
+export function getEntityPicture(stateObj: HassEntity) {
     return (
-        (entity.attributes.entity_picture_local as string | undefined) ||
-        entity.attributes.entity_picture
+        (stateObj.attributes.entity_picture_local as string | undefined) ||
+        stateObj.attributes.entity_picture
     );
 }

--- a/src/ha/data/update.ts
+++ b/src/ha/data/update.ts
@@ -1,5 +1,6 @@
 import type {
     HassEntities,
+    HassEntity,
     HassEntityAttributeBase,
     HassEntityBase,
 } from "home-assistant-js-websocket";
@@ -57,7 +58,7 @@ export const updateReleaseNotes = (hass: HomeAssistant, entityId: string) =>
 export const filterUpdateEntities = (entities: HassEntities, language?: string) =>
     (
         Object.values(entities).filter(
-            (entity) => computeStateDomain(entity) === "update"
+            (stateObj) => computeStateDomain(stateObj) === "update"
         ) as UpdateEntity[]
     ).sort((a, b) => {
         if (a.attributes.title === "Home Assistant Core") {

--- a/src/ha/panels/lovelace/common/entity/toggle-entity.ts
+++ b/src/ha/panels/lovelace/common/entity/toggle-entity.ts
@@ -6,6 +6,7 @@ export const toggleEntity = (
     hass: HomeAssistant,
     entityId: string
 ): Promise<ServiceCallResponse> => {
-    const turnOn = STATES_OFF.includes(hass.states[entityId].state);
+    const stateObj = hass.states[entityId];
+    const turnOn = stateObj && STATES_OFF.includes(stateObj.state);
     return turnOnOffEntity(hass, entityId, turnOn);
 };

--- a/src/ha/panels/lovelace/common/entity/turn-on-off-entities.ts
+++ b/src/ha/panels/lovelace/common/entity/turn-on-off-entities.ts
@@ -9,7 +9,8 @@ export const turnOnOffEntities = (
 ): void => {
     const domainsToCall = {};
     entityIds.forEach((entityId) => {
-        if (STATES_OFF.includes(hass.states[entityId].state) === turnOn) {
+        const stateObj = hass.states[entityId];
+        if (stateObj && STATES_OFF.includes(stateObj.state) === turnOn) {
             const stateDomain = computeDomain(entityId);
             const serviceDomain = ["cover", "lock"].includes(stateDomain)
                 ? stateDomain

--- a/src/ha/panels/lovelace/common/validate-condition.ts
+++ b/src/ha/panels/lovelace/common/validate-condition.ts
@@ -9,7 +9,7 @@ export interface Condition {
 
 export function checkConditionsMet(conditions: Condition[], hass: HomeAssistant): boolean {
     return conditions.every((c) => {
-        const state = hass.states[c.entity] ? hass!.states[c.entity].state : UNAVAILABLE;
+        const state = hass.states[c.entity] ? hass!.states[c.entity]?.state : UNAVAILABLE;
 
         return c.state ? state === c.state : state !== c.state_not;
     });

--- a/src/shared/chip.ts
+++ b/src/shared/chip.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing, TemplateResult } from "lit";
 import { property, customElement } from "lit/decorators.js";
 
 @customElement("mushroom-chip")
@@ -14,14 +14,14 @@ export class Chip extends LitElement {
     protected render(): TemplateResult {
         return html`
             <ha-card>
-                ${this.avatar ? html` <img class="avatar" src=${this.avatar} /> ` : null}
+                ${this.avatar ? html` <img class="avatar" src=${this.avatar} /> ` : nothing}
                 ${!this.avatarOnly
                     ? html`
                           <div class="content">
                               <slot></slot>
                           </div>
                       `
-                    : null}
+                    : nothing}
             </ha-card>
         `;
     }

--- a/src/shared/input-number.ts
+++ b/src/shared/input-number.ts
@@ -90,7 +90,11 @@ export class InputNumber extends LitElement {
 
         return html`
             <div class="container" id="container">
-                <button class="button minus" @click=${this._decrementValue} .disabled=${this.disabled}>
+                <button
+                    class="button minus"
+                    @click=${this._decrementValue}
+                    .disabled=${this.disabled}
+                >
                     <ha-icon icon="mdi:minus"></ha-icon>
                 </button>
                 <span
@@ -102,7 +106,11 @@ export class InputNumber extends LitElement {
                 >
                     ${value}
                 </span>
-                <button class="button plus" @click=${this._incrementValue} .disabled=${this.disabled}>
+                <button
+                    class="button plus"
+                    @click=${this._incrementValue}
+                    .disabled=${this.disabled}
+                >
                     <ha-icon icon="mdi:plus"></ha-icon>
                 </button>
             </div>

--- a/src/shared/shape-icon.ts
+++ b/src/shared/shape-icon.ts
@@ -7,14 +7,14 @@ import { animations } from "../utils/entity-styles";
 export class ShapeIcon extends LitElement {
     @property() public icon: string = "";
 
-    @property() public disabled: boolean = false;
+    @property({ type: Boolean }) public disabled?: boolean;
 
     protected render(): TemplateResult {
         return html`
             <div
                 class=${classMap({
                     shape: true,
-                    disabled: this.disabled,
+                    disabled: Boolean(this.disabled),
                 })}
             >
                 <ha-icon .icon=${this.icon} />

--- a/src/shared/slider.ts
+++ b/src/shared/slider.ts
@@ -1,4 +1,12 @@
-import { css, CSSResultGroup, html, LitElement, PropertyValues, TemplateResult } from "lit";
+import {
+    css,
+    CSSResultGroup,
+    html,
+    LitElement,
+    nothing,
+    PropertyValues,
+    TemplateResult,
+} from "lit";
 import { customElement, property, query, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { styleMap } from "lit/directives/style-map.js";
@@ -171,8 +179,10 @@ export class SliderItem extends LitElement {
                     })}
                 >
                     <div class="slider-track-background"></div>
-                    ${this.showActive ? html`<div class="slider-track-active"></div>` : null}
-                    ${this.showIndicator ? html`<div class="slider-track-indicator"></div>` : null}
+                    ${this.showActive ? html`<div class="slider-track-active"></div>` : nothing}
+                    ${this.showIndicator
+                        ? html`<div class="slider-track-indicator"></div>`
+                        : nothing}
                 </div>
             </div>
         `;

--- a/src/shared/state-info.ts
+++ b/src/shared/state-info.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing, TemplateResult } from "lit";
 import { property, customElement } from "lit/decorators.js";
 
 @customElement("mushroom-state-info")
@@ -18,7 +18,7 @@ export class StateItem extends LitElement {
                           class="secondary${this.multiline_secondary ? ` multiline_secondary` : ``}"
                           >${this.secondary}</span
                       >`
-                    : null}
+                    : nothing}
             </div>
         `;
     }

--- a/src/shared/state-item.ts
+++ b/src/shared/state-item.ts
@@ -1,4 +1,4 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import { css, CSSResultGroup, html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { Appearance } from "./config/appearance-config";
@@ -23,7 +23,7 @@ export class StateItem extends LitElement {
                               <slot name="badge"></slot>
                           </div>
                       `
-                    : null}
+                    : nothing}
                 ${this.appearance?.primary_info !== "none" ||
                 this.appearance?.secondary_info !== "none"
                     ? html`
@@ -31,7 +31,7 @@ export class StateItem extends LitElement {
                               <slot name="info"></slot>
                           </div>
                       `
-                    : null}
+                    : nothing}
             </div>
         `;
     }

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -173,5 +173,8 @@
                 }
             }
         }
+    },
+    "card": {
+        "not_found": "Entity not found"
     }
 }

--- a/src/utils/base-card.ts
+++ b/src/utils/base-card.ts
@@ -25,8 +25,8 @@ export class MushroomBaseCard extends MushroomBaseElement {
         `;
     }
 
-    protected renderIcon(entity: HassEntity, icon: string): TemplateResult {
-        const active = isActive(entity);
+    protected renderIcon(stateObj: HassEntity, icon: string): TemplateResult {
+        const active = isActive(stateObj);
         return html`
             <mushroom-shape-icon
                 slot="icon"
@@ -36,8 +36,8 @@ export class MushroomBaseCard extends MushroomBaseElement {
         `;
     }
 
-    protected renderBadge(entity: HassEntity) {
-        const unavailable = !isAvailable(entity);
+    protected renderBadge(stateObj: HassEntity) {
+        const unavailable = !isAvailable(stateObj);
         return unavailable
             ? html`
                   <mushroom-badge-icon
@@ -50,14 +50,14 @@ export class MushroomBaseCard extends MushroomBaseElement {
     }
 
     protected renderStateInfo(
-        entity: HassEntity,
+        stateObj: HassEntity,
         appearance: Appearance,
         name: string,
         state?: string
     ): TemplateResult | null {
         const defaultState = computeStateDisplay(
             this.hass.localize,
-            entity,
+            stateObj,
             this.hass.locale,
             this.hass.entities,
             this.hass.connection.haVersion
@@ -68,7 +68,7 @@ export class MushroomBaseCard extends MushroomBaseElement {
             appearance.primary_info,
             name,
             displayState,
-            entity,
+            stateObj,
             this.hass
         );
 
@@ -76,7 +76,7 @@ export class MushroomBaseCard extends MushroomBaseElement {
             appearance.secondary_info,
             name,
             displayState,
-            entity,
+            stateObj,
             this.hass
         );
 

--- a/src/utils/base-card.ts
+++ b/src/utils/base-card.ts
@@ -1,15 +1,21 @@
 import { HassEntity } from "home-assistant-js-websocket";
 import { html, nothing, TemplateResult } from "lit";
-import { computeStateDisplay, HomeAssistant, isActive, isAvailable } from "../ha";
+import { classMap } from "lit/directives/class-map.js";
+import { computeRTL, computeStateDisplay, HomeAssistant, isActive, isAvailable } from "../ha";
+import setupCustomlocalize from "../localize";
 import "../shared/badge-icon";
 import "../shared/card";
-import { Appearance } from "../shared/config/appearance-config";
+import { Appearance, AppearanceSharedConfig } from "../shared/config/appearance-config";
+import { EntitySharedConfig } from "../shared/config/entity-config";
 import "../shared/shape-avatar";
 import "../shared/shape-icon";
 import "../shared/state-info";
 import "../shared/state-item";
+import { computeAppearance } from "./appearance";
 import { MushroomBaseElement } from "./base-element";
 import { computeInfoDisplay } from "./info";
+
+type BaseConfig = EntitySharedConfig & AppearanceSharedConfig;
 
 export function computeDarkMode(hass?: HomeAssistant): boolean {
     if (!hass) return false;
@@ -22,6 +28,37 @@ export class MushroomBaseCard extends MushroomBaseElement {
                 slot="icon"
                 .picture_url=${(this.hass as any).hassUrl(picture)}
             ></mushroom-shape-avatar>
+        `;
+    }
+
+    protected renderNotFound(config: BaseConfig): TemplateResult {
+        const appearance = computeAppearance(config);
+        const rtl = computeRTL(this.hass);
+
+        const customLocalize = setupCustomlocalize(this.hass);
+
+        return html`
+            <ha-card class=${classMap({ "fill-container": appearance.fill_container })}>
+                <mushroom-card .appearance=${appearance} ?rtl=${rtl}>
+                    <mushroom-state-item ?rtl=${rtl} .appearance=${appearance} disabled>
+                        <mushroom-shape-icon
+                            slot="icon"
+                            disabled
+                            icon="mdi:help"
+                        ></mushroom-shape-icon>
+                        <mushroom-badge-icon
+                            slot="badge"
+                            class="not-found"
+                            icon="mdi:exclamation-thick"
+                        ></mushroom-badge-icon>
+                        <mushroom-state-info
+                            slot="info"
+                            .primary=${config.entity}
+                            secondary=${customLocalize("card.not_found")}
+                        ></mushroom-state-info>
+                    </mushroom-state-item>
+                </mushroom-card>
+            </ha-card>
         `;
     }
 

--- a/src/utils/base-card.ts
+++ b/src/utils/base-card.ts
@@ -1,5 +1,5 @@
 import { HassEntity } from "home-assistant-js-websocket";
-import { html, TemplateResult } from "lit";
+import { html, nothing, TemplateResult } from "lit";
 import { computeStateDisplay, HomeAssistant, isActive, isAvailable } from "../ha";
 import "../shared/badge-icon";
 import "../shared/card";
@@ -9,7 +9,7 @@ import "../shared/shape-icon";
 import "../shared/state-info";
 import "../shared/state-item";
 import { MushroomBaseElement } from "./base-element";
-import { computeEntityPicture, computeInfoDisplay } from "./info";
+import { computeInfoDisplay } from "./info";
 
 export function computeDarkMode(hass?: HomeAssistant): boolean {
     if (!hass) return false;
@@ -36,7 +36,7 @@ export class MushroomBaseCard extends MushroomBaseElement {
         `;
     }
 
-    protected renderBadge(entity: HassEntity): TemplateResult | null {
+    protected renderBadge(entity: HassEntity) {
         const unavailable = !isAvailable(entity);
         return unavailable
             ? html`
@@ -46,7 +46,7 @@ export class MushroomBaseCard extends MushroomBaseElement {
                       icon="mdi:help"
                   ></mushroom-badge-icon>
               `
-            : null;
+            : nothing;
     }
 
     protected renderStateInfo(

--- a/src/utils/card-styles.ts
+++ b/src/utils/card-styles.ts
@@ -34,6 +34,12 @@ export const cardStyle = css`
         margin-left: var(--spacing);
     }
     .unavailable {
-        --main-color: var(--warning-color);
+        --main-color: rgb(var(--rgb-warning));
+    }
+    .not-found {
+        --main-color: rgb(var(--rgb-danger));
+    }
+    mushroom-state-item[disabled] {
+        cursor: initial;
     }
 `;

--- a/src/utils/icons/sensor-icon.ts
+++ b/src/utils/icons/sensor-icon.ts
@@ -76,8 +76,8 @@ const BATTERY_CHARGING_ICONS = {
     100: "mdi:battery-charging",
 };
 
-const batteryStateIcon = (batteryEntity: HassEntity, batteryChargingEntity?: HassEntity) => {
-    const battery = batteryEntity.state;
+const batteryStateIcon = (stateObj: HassEntity, batteryChargingEntity?: HassEntity) => {
+    const battery = stateObj.state;
     const batteryCharging = batteryChargingEntity?.state === "on";
 
     return batteryIcon(battery, batteryCharging);

--- a/src/utils/icons/state-icon.ts
+++ b/src/utils/icons/state-icon.ts
@@ -2,14 +2,14 @@ import { HassEntity } from "home-assistant-js-websocket";
 import { computeDomain } from "../../ha";
 import { domainIcon } from "./domain-icon";
 
-export function stateIcon(entity: HassEntity): string {
-    if (entity.attributes.icon) {
-        return entity.attributes.icon;
+export function stateIcon(stateObj: HassEntity): string {
+    if (stateObj.attributes.icon) {
+        return stateObj.attributes.icon;
     }
 
-    const domain = computeDomain(entity.entity_id);
+    const domain = computeDomain(stateObj.entity_id);
 
-    const state = entity.state;
+    const state = stateObj.state;
 
-    return domainIcon(domain, entity, state);
+    return domainIcon(domain, stateObj, state);
 }

--- a/src/utils/info.ts
+++ b/src/utils/info.ts
@@ -14,24 +14,24 @@ export function computeInfoDisplay(
     info: Info,
     name: string,
     state: string,
-    entity: HassEntity,
+    stateObj: HassEntity,
     hass: HomeAssistant
 ) {
     switch (info) {
         case "name":
             return name;
         case "state":
-            const domain = entity.entity_id.split(".")[0];
+            const domain = stateObj.entity_id.split(".")[0];
             if (
-                (entity.attributes.device_class === "timestamp" ||
+                (stateObj.attributes.device_class === "timestamp" ||
                     TIMESTAMP_STATE_DOMAINS.includes(domain)) &&
-                isAvailable(entity) &&
-                !isUnknown(entity)
+                isAvailable(stateObj) &&
+                !isUnknown(stateObj)
             ) {
                 return html`
                     <ha-relative-time
                         .hass=${hass}
-                        .datetime=${entity.state}
+                        .datetime=${stateObj.state}
                         capitalize
                     ></ha-relative-time>
                 `;
@@ -42,7 +42,7 @@ export function computeInfoDisplay(
             return html`
                 <ha-relative-time
                     .hass=${hass}
-                    .datetime=${entity.last_changed}
+                    .datetime=${stateObj.last_changed}
                     capitalize
                 ></ha-relative-time>
             `;
@@ -50,7 +50,7 @@ export function computeInfoDisplay(
             return html`
                 <ha-relative-time
                     .hass=${hass}
-                    .datetime=${entity.last_updated}
+                    .datetime=${stateObj.last_updated}
                     capitalize
                 ></ha-relative-time>
             `;
@@ -59,6 +59,6 @@ export function computeInfoDisplay(
     }
 }
 
-export function computeEntityPicture(entity: HassEntity, iconType: IconType) {
-    return iconType === "entity-picture" ? getEntityPicture(entity) : undefined;
+export function computeEntityPicture(stateObj: HassEntity, iconType: IconType) {
+    return iconType === "entity-picture" ? getEntityPicture(stateObj) : undefined;
 }


### PR DESCRIPTION
## Description

- [x] Gracefully handle not found entity states (return not found card) 
- [x] Use `nothing` instead of `html''` or `null`
- [x] Rename `entity` to `stateObj`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #602, fixes #880

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
