### PR TITLE
Add support for weather icon in template card and template chip

### DIFF
--- a/docs/cards/chips.md
+++ b/docs/cards/chips.md
@@ -71,7 +71,7 @@ A spacer chip allows you to space chips apart.
 ![Chip template light](../images/chip-template-light.png)
 ![Chip template dark](../images/chip-template-dark.png)
 
-A template chip allows you to build custom chip using [templates](https://www.home-assistant.io/docs/configuration/templating/).
+A template chip allows you to build custom chip using [templates](https://www.home-assistant.io/docs/configuration/templating/) \*.
 
 ### Weather chip
 
@@ -79,3 +79,23 @@ A template chip allows you to build custom chip using [templates](https://www.ho
 ![Chip weather dark](../images/chip-weather-dark.png)
 
 A weather chip allows you to display the weather.
+
+#### Notes
+
+\* You can render weather svg icons using [weather state](https://developers.home-assistant.io/docs/core/entity/weather/#recommended-values-for-state-and-condition) as icon :
+
+-   clear-night
+-   cloudy
+-   fog
+-   lightning
+-   lightning-rainy
+-   partlycloudy
+-   pouring
+-   rainy
+-   hail
+-   snowy
+-   snowy-rainy
+-   sunny
+-   windy
+-   windy-variant
+-   exceptional (not supported)

--- a/docs/cards/template.md
+++ b/docs/cards/template.md
@@ -13,7 +13,7 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 
 | Name                  | Type            | Default     | Description                                                                                                                         |
 | :-------------------- | :-------------- | :---------- | :---------------------------------------------------------------------------------------------------------------------------------- |
-| `icon`                | string          | Optional    | Icon to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                              |
+| `icon`                | string          | Optional    | Icon to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/) \*.                           |
 | `icon_color`          | string          | Optional    | Icon color to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                        |
 | `primary`             | string          | Optional    | Primary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                      |
 | `secondary`           | string          | Optional    | Secondary info to render. May contain [templates](https://www.home-assistant.io/docs/configuration/templating/).                    |
@@ -27,3 +27,23 @@ All the options are available in the lovelace editor but you can use `yaml` if y
 | `hold_action`         | action          | `none`      | Home assistant action to perform on hold                                                                                            |
 | `entity_id`           | `string` `list` | Optional    | Only reacts to the state changes of these entities. This can be used if the automatic analysis fails to find all relevant entities. |
 | `double_tap_action`   | action          | `more-info` | Home assistant action to perform on double_tap                                                                                      |
+
+#### Notes
+
+\* You can render weather svg icons using [weather state](https://developers.home-assistant.io/docs/core/entity/weather/#recommended-values-for-state-and-condition) as icon :
+
+-   clear-night
+-   cloudy
+-   fog
+-   lightning
+-   lightning-rainy
+-   partlycloudy
+-   pouring
+-   rainy
+-   hail
+-   snowy
+-   snowy-rainy
+-   sunny
+-   windy
+-   windy-variant
+-   exceptional (not supported)

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -27,6 +27,8 @@ import {
 } from "../../../utils/lovelace/chip/chip-element";
 import { LovelaceChip, TemplateChipConfig } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
+import { getWeatherStateSVG, weatherSVGStyles } from "../../../utils/weather";
+import { weatherSVGs } from "../../../utils/icons/weather-icon";
 
 const TEMPLATE_KEYS = ["content", "icon", "icon_color", "picture"] as const;
 type TemplateKey = (typeof TEMPLATE_KEYS)[number];
@@ -109,6 +111,9 @@ export class TemplateChip extends LitElement implements LovelaceChip {
 
         const rtl = computeRTL(this.hass);
 
+        const weatherSvg =
+            icon && weatherSVGs.has(icon) ? getWeatherStateSVG(icon, true) : undefined;
+
         return html`
             <mushroom-chip
                 ?rtl=${rtl}
@@ -120,7 +125,13 @@ export class TemplateChip extends LitElement implements LovelaceChip {
                 .avatar=${picture ? (this.hass as any).hassUrl(picture) : undefined}
                 .avatarOnly=${picture && !content}
             >
-                ${icon && !picture ? this.renderIcon(icon, iconColor) : nothing}
+                ${!picture
+                    ? weatherSvg
+                        ? weatherSvg
+                        : icon
+                        ? this.renderIcon(icon, iconColor)
+                        : nothing
+                    : nothing}
                 ${content ? this.renderContent(content) : nothing}
             </mushroom-chip>
         `;
@@ -236,6 +247,7 @@ export class TemplateChip extends LitElement implements LovelaceChip {
             ha-icon {
                 color: var(--color);
             }
+            ${weatherSVGStyles}
         `;
     }
 }

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -23,6 +23,8 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
 import { registerCustomCard } from "../../utils/custom-cards";
+import { weatherSVGs } from "../../utils/icons/weather-icon";
+import { getWeatherStateSVG, weatherSVGStyles } from "../../utils/weather";
 import { TEMPLATE_CARD_EDITOR_NAME, TEMPLATE_CARD_NAME } from "./const";
 import { TemplateCardConfig } from "./template-card-config";
 
@@ -137,6 +139,9 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
             secondary_info: Boolean(secondary) ? "state" : "none",
         });
 
+        const weatherSvg =
+            icon && weatherSVGs.has(icon) ? getWeatherStateSVG(icon, true) : undefined;
+
         return html`
             <ha-card class=${classMap({ "fill-container": appearance.fill_container })}>
                 <mushroom-card .appearance=${appearance} ?rtl=${rtl}>
@@ -151,6 +156,8 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
                     >
                         ${picture
                             ? this.renderPicture(picture)
+                            : weatherSvg
+                            ? html`<div slot="icon">${weatherSvg}</div>`
                             : icon
                             ? this.renderIcon(icon, iconColor)
                             : nothing}
@@ -310,6 +317,12 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
                     --icon-color: rgb(var(--rgb-disabled));
                     --shape-color: rgba(var(--rgb-disabled), 0.2);
                 }
+                svg {
+                    width: var(--icon-size);
+                    height: var(--icon-size);
+                    display: flex;
+                }
+                ${weatherSVGStyles}
             `,
         ];
     }

--- a/src/utils/icons/weather-icon.ts
+++ b/src/utils/icons/weather-icon.ts
@@ -16,6 +16,23 @@ const weatherIcons = {
     "windy-variant": "mdi:weather-windy-variant",
 };
 
+export const weatherSVGs = new Set<string>([
+    "clear-night",
+    "cloudy",
+    "fog",
+    "lightning",
+    "lightning-rainy",
+    "partlycloudy",
+    "pouring",
+    "rainy",
+    "hail",
+    "snowy",
+    "snowy-rainy",
+    "sunny",
+    "windy",
+    "windy-variant",
+]);
+
 export const weatherIcon = (state?: string, nightTime?: boolean): string =>
     !state
         ? undefined


### PR DESCRIPTION
## Description

Add support for weather svg icon in template card and template chip

![CleanShot 2023-06-17 at 15 16 52@2x](https://github.com/piitaya/lovelace-mushroom/assets/5878303/a0a2b303-cae2-4db4-acf9-930a58b4f4c8)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes https://github.com/piitaya/lovelace-mushroom/issues/1070

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
