### PR TITLE
remove box-shadow from title card

### DIFF
--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -269,6 +269,7 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
                     padding: var(--title-padding);
                     background: none;
                     border: none;
+                    box-shadow: none;
                 }
                 .header div * {
                     margin: 0;


### PR DESCRIPTION
## Description

This fixes the box-shadow that the title card displays after the ha-card update

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #1177

## Motivation and Context

Previously the title card did not have any border/shadow and I think it is an error/oversight that it has one now.

## How Has This Been Tested

CSS tested in chrome developer tools. Updated code manually in mushroom.js to apply the fix there and it works

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
