### PR TITLE
Fix/cs translation

### DIFF
--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -56,7 +56,7 @@
             },
             "light": {
                 "show_brightness_control": "Ovládání jasu?",
-                "use_light_color": "Použít ovládání světla",
+                "use_light_color": "Upravit ikonu podle barvy světla?",
                 "show_color_temp_control": "Ovládání teploty světla?",
                 "show_color_control": "Ovládání barvy světla?",
                 "incompatible_controls": "Některé ovládací prvky se nemusí zobrazit, pokud vaše světlo tuto funkci nepodporuje."

--- a/src/translations/cs.json
+++ b/src/translations/cs.json
@@ -56,7 +56,7 @@
             },
             "light": {
                 "show_brightness_control": "Ovládání jasu?",
-                "use_light_color": "Upravit ikonu podle barvy světla?",
+                "use_light_color": "Ikona podle barvy světla?",
                 "show_color_temp_control": "Ovládání teploty světla?",
                 "show_color_control": "Ovládání barvy světla?",
                 "incompatible_controls": "Některé ovládací prvky se nemusí zobrazit, pokud vaše světlo tuto funkci nepodporuje."


### PR DESCRIPTION
## Description

Update incorrect translation for setting the color of the icon based on the light color.

## Related Issue

This PR fixes or closes issue: fixes [[Feature]: Change light icon based on the light color #1208](https://github.com/piitaya/lovelace-mushroom/issues/1208)

## Motivation and Context

The incorrect translation in Czech language made it very confusing. I have updated the translation so now it is more straight forward. Originally the translation was "Použít ovládání světla" -> "Use light control" and I have changed it to "Ikona podle barvy světla" -> "Icon based on color of the light".

## How Has This Been Tested

I have started the docker container with ha and went to light setting and checked the translation. 
<img width="1023" alt="image" src="https://github.com/piitaya/lovelace-mushroom/assets/32042186/e9d03a24-2b46-4046-81d0-492b72c2f7c8">


## Types of changes

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [x] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
