### PR TITLE
Climate card change

### DIFF
--- a/.hass_dev/lovelace-mushroom-showcase.yaml
+++ b/.hass_dev/lovelace-mushroom-showcase.yaml
@@ -5,6 +5,7 @@ views:
   - !include views/person-view.yaml
   - !include views/alarm-control-panel-view.yaml
   - !include views/fan-view.yaml
+  - !include views/climate-view.yaml
   - !include views/template-view.yaml
   - !include views/entity-view.yaml
   - !include views/chips-view.yaml

--- a/.hass_dev/views/climate-view.yaml
+++ b/.hass_dev/views/climate-view.yaml
@@ -1,0 +1,49 @@
+title: Climate
+icon: mdi:home-thermometer
+cards:
+  - type: grid
+    title: Basic
+    cards:
+      - type: custom:mushroom-climate-card
+        entity: climate.ecobee
+        show_target_temperature: true
+      - type: custom:mushroom-climate-card
+        entity: climate.heatpump
+        show_target_temperature: true
+      - type: custom:mushroom-climate-card
+        entity: climate.hvac
+        show_target_temperature: true
+    columns: 2
+    square: false
+  - type: grid
+    title: Controls
+    cards:
+      - type: custom:mushroom-climate-card
+        entity: climate.ecobee
+        name: Percentage control
+        show_temperature_control: true
+      - type: custom:mushroom-climate-card
+        entity: climate.hvac
+        name: Multiple controls
+        show_temperature_control: true
+        hvac_modes: 
+          - auto
+          - heat_cool
+          - heat
+          - cool
+          - dry
+          - fan_only
+      - type: custom:mushroom-climate-card
+        entity: climate.hvac
+        name: Collapsible controls
+        show_temperature_control: true
+        hvac_modes: 
+          - auto
+          - heat_cool
+          - heat
+          - cool
+          - dry
+          - fan_only
+        collapsible_controls: true
+    columns: 2
+    square: false

--- a/src/cards/climate-card/climate-card-config.ts
+++ b/src/cards/climate-card/climate-card-config.ts
@@ -23,6 +23,7 @@ export type ClimateCardConfig = LovelaceCardConfig &
     AppearanceSharedConfig &
     ActionsSharedConfig & {
         show_temperature_control?: false;
+        show_target_temperature?: false;
         hvac_modes?: HvacMode[];
         collapsible_controls?: boolean;
     };
@@ -32,6 +33,7 @@ export const climateCardConfigStruct = assign(
     assign(entitySharedConfigStruct, appearanceSharedConfigStruct, actionsSharedConfigStruct),
     object({
         show_temperature_control: optional(boolean()),
+        show_target_temperature: optional(boolean()),
         hvac_modes: optional(array(string())),
         collapsible_controls: optional(boolean()),
     })

--- a/src/cards/climate-card/climate-card-editor.ts
+++ b/src/cards/climate-card/climate-card-editor.ts
@@ -13,7 +13,7 @@ import { loadHaComponents } from "../../utils/loader";
 import { ClimateCardConfig, climateCardConfigStruct, HVAC_MODES } from "./climate-card-config";
 import { CLIMATE_CARD_EDITOR_NAME, CLIMATE_ENTITY_DOMAINS } from "./const";
 
-const CLIMATE_LABELS = ["hvac_modes", "show_temperature_control"] as string[];
+const CLIMATE_LABELS = ["hvac_modes", "show_temperature_control", "show_target_temperature"] as string[];
 
 const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
     { name: "entity", selector: { entity: { domain: CLIMATE_ENTITY_DOMAINS } } },
@@ -38,6 +38,7 @@ const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
                 },
             },
             { name: "show_temperature_control", selector: { boolean: {} } },
+            { name: "show_target_temperature", selector: { boolean: {} } },
             { name: "collapsible_controls", selector: { boolean: {} } },
         ],
     },

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -144,6 +144,7 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
 
         const name = this._config.name || stateObj.attributes.friendly_name || "";
         const icon = this._config.icon;
+        const showTargetTemperature = this._config.show_target_temperature
         const appearance = computeAppearance(this._config);
         const picture = computeEntityPicture(stateObj, appearance.icon_type);
 
@@ -154,6 +155,12 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
             this.hass.config,
             this.hass.entities
         );
+
+        if (showTargetTemperature && stateObj.state !== "off") {
+            const targetTemperature = this._computeTarget(stateObj);
+            stateDisplay += ` (${targetTemperature})`;
+        }
+
         if (stateObj.attributes.current_temperature !== null) {
             const temperature = formatNumber(
                 stateObj.attributes.current_temperature,
@@ -292,4 +299,52 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
             `,
         ];
     }
+
+    // ported from https://github.com/home-assistant/frontend/blob/d3ba19b0e00de1de14b4a17b331210325de8614e/src/components/ha-climate-state.ts#L43
+    private _computeTarget(stateObj: ClimateEntity): string {
+        if (!this.hass || !stateObj) {
+          return "";
+        }
+    
+        if (
+          stateObj.attributes.target_temp_low != null &&
+          stateObj.attributes.target_temp_high != null
+        ) {
+          return `${formatNumber(
+            stateObj.attributes.target_temp_low,
+            this.hass.locale
+          )}-${formatNumber(
+            stateObj.attributes.target_temp_high,
+            this.hass.locale
+          )} ${this.hass.config.unit_system.temperature}`;
+        }
+    
+        if (stateObj.attributes.temperature != null) {
+          return `${formatNumber(
+            stateObj.attributes.temperature,
+            this.hass.locale
+          )} ${this.hass.config.unit_system.temperature}`;
+        }
+        if (
+          stateObj.attributes.target_humidity_low != null &&
+          stateObj.attributes.target_humidity_high != null
+        ) {
+          return `${formatNumber(
+            stateObj.attributes.target_humidity_low,
+            this.hass.locale
+          )}-${formatNumber(
+            stateObj.attributes.target_humidity_high,
+            this.hass.locale
+          )} %`;
+        }
+    
+        if (stateObj.attributes.humidity != null) {
+          return `${formatNumber(
+            stateObj.attributes.humidity,
+            this.hass.locale
+          )} %`;
+        }
+    
+        return "";
+      }
 }


### PR DESCRIPTION
## Description

Add target temperature to climate-card
    
* Introduces `show_target_temperature` configuration param for climate-card
* Adds climate-view to showcase for development

## Related Issue
 
This PR closes issue: fixes #636 

## Motivation and Context

The default climate entity card shows both the target temperature and the current temperature. This change adds the target temperature to be displayed when the climate device is turned on.

To gate the change and prevent dashboards from automatically changing their appearance a new configuration parameter is introduced called `show_target_temperature` which defaults to false.

**HASS Entity Card Climate Appearance**

<img width="391" alt="image" src="https://github.com/piitaya/lovelace-mushroom/assets/1447443/f60716f0-1512-4011-9ec6-1222cc140e25">

**Mushroom `show_target_temperature: false`**

<img width="253" alt="image" src="https://github.com/piitaya/lovelace-mushroom/assets/1447443/b40e5c5c-bcc0-4389-b4a3-197e2451432f">


**Mushroom `show_target_temperature: true`**

<img width="256" alt="image" src="https://github.com/piitaya/lovelace-mushroom/assets/1447443/bf74a5a2-d2e4-43d4-8ded-4cfd6b2170b5">

**New Showcase View**

<img width="1437" alt="image" src="https://github.com/piitaya/lovelace-mushroom/assets/1447443/32976d44-3ea2-4b6e-b0fa-1647ba80aab1">


## How Has This Been Tested

`climate-view` added to showcase. Testing done with manually (screenshots above)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [x] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
