### PR TITLE
Fix fan card displaying 0% when off

### DIFF
--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -132,7 +132,7 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                   this.hass.config,
                   this.hass.entities
               );
-        if (this.percentage != null) {
+        if (this.percentage != null && stateObj.state === "on") {
             stateDisplay = `${this.percentage}${blankBeforePercent(this.hass.locale)}%`;
         }
 


### PR DESCRIPTION
## Description
Fix the bug where the fan card displays 0% instead of "Off" when the fan is off.

This logic looks like it was copied from the light card. However, with light entities, `this.brightness` is `undefined` when the light is off, but with fan entities, `this.percentage` is `0` when the fan is off. So, fan entities need different logic.

Before:
![image](https://github.com/piitaya/lovelace-mushroom/assets/2292715/9bea4c3e-37f5-4b49-afc3-c005c954c621)

After:
![image](https://github.com/piitaya/lovelace-mushroom/assets/2292715/a241ccf3-6fb6-4c24-9aab-07ceae2c21e7)


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes https://github.com/piitaya/lovelace-mushroom/issues/851


## Motivation and Context

Improves user experience by making state display consistent between lights and fans.

## How Has This Been Tested

Tested locally with docker setup (`npm run start:hass`).

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
