### PR TITLE
Add support icon in 2024.2

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -269,7 +269,12 @@ export class AlarmControlPanelCard extends MushroomBaseCard implements LovelaceC
                 style=${styleMap(iconStyle)}
                 class=${classMap({ pulse: shapePulse })}
             >
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/chips-card/chips/action-chip.ts
+++ b/src/cards/chips-card/chips/action-chip.ts
@@ -71,7 +71,11 @@ export class ActionChip extends LitElement implements LovelaceChip {
                     hasDoubleClick: hasAction(this._config.double_tap_action),
                 })}
             >
-                <ha-state-icon .icon=${icon} style=${styleMap(iconStyle)}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .icon=${icon}
+                    style=${styleMap(iconStyle)}
+                ></ha-state-icon>
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -113,6 +113,8 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
                 })}
             >
                 <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
                     .state=${stateObj}
                     .icon=${icon}
                     style=${styleMap(iconStyle)}

--- a/src/cards/chips-card/chips/back-chip.ts
+++ b/src/cards/chips-card/chips/back-chip.ts
@@ -50,7 +50,7 @@ export class BackChip extends LitElement implements LovelaceChip {
                 @action=${this._handleAction}
                 .actionHandler=${actionHandler()}
             >
-                <ha-state-icon .icon=${icon}></ha-state-icon>
+                <ha-state-icon .hass=${this.hass} .icon=${icon}></ha-state-icon>
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -122,6 +122,8 @@ export class EntityChip extends LitElement implements LovelaceChip {
         }
         return html`
             <ha-state-icon
+                .hass=${this.hass}
+                .stateObj=${stateObj}
                 .state=${stateObj}
                 .icon=${icon}
                 style=${styleMap(iconStyle)}

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -117,6 +117,8 @@ export class LightChip extends LitElement implements LovelaceChip {
                 })}
             >
                 <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
                     .state=${stateObj}
                     .icon=${icon}
                     style=${styleMap(iconStyle)}

--- a/src/cards/chips-card/chips/menu-chip.ts
+++ b/src/cards/chips-card/chips/menu-chip.ts
@@ -50,7 +50,7 @@ export class MenuChip extends LitElement implements LovelaceChip {
                 @action=${this._handleAction}
                 .actionHandler=${actionHandler()}
             >
-                <ha-state-icon .icon=${icon}></ha-state-icon>
+                <ha-state-icon .hass=${this.hass} .icon=${icon}></ha-state-icon>
             </mushroom-chip>
         `;
     }

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -141,7 +141,11 @@ export class TemplateChip extends LitElement implements LovelaceChip {
             const iconRgbColor = computeRgbColor(iconColor);
             iconStyle["--color"] = `rgb(${iconRgbColor})`;
         }
-        return html`<ha-state-icon .icon=${icon} style=${styleMap(iconStyle)}></ha-state-icon>`;
+        return html`<ha-state-icon
+            .hass=${this.hass}
+            .icon=${icon}
+            style=${styleMap(iconStyle)}
+        ></ha-state-icon>`;
     }
 
     protected renderContent(content: string): TemplateResult {

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -203,7 +203,12 @@ export class ClimateCard extends MushroomBaseCard implements LovelaceCard {
 
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!available} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -217,7 +217,12 @@ export class CoverCard extends MushroomBaseCard implements LovelaceCard {
 
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!available} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon
             ></mushroom-shape-icon>
         `;
     }

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -124,7 +124,12 @@ export class EntityCard extends MushroomBaseCard implements LovelaceCard {
         }
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!active} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -208,7 +208,12 @@ export class FanCard extends MushroomBaseCard implements LovelaceCard {
                 style=${styleMap(iconStyle)}
                 .disabled=${!active}
             >
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -245,7 +245,12 @@ export class LightCard extends MushroomBaseCard implements LovelaceCard {
         }
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!active} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -145,7 +145,12 @@ export class LockCard extends MushroomBaseCard implements LovelaceCard {
 
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!available} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/number-card/number-card.ts
+++ b/src/cards/number-card/number-card.ts
@@ -192,7 +192,12 @@ export class NumberCard extends MushroomBaseCard implements LovelaceCard {
         }
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!active} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/select-card/select-card.ts
+++ b/src/cards/select-card/select-card.ts
@@ -140,7 +140,12 @@ export class SelectCard extends MushroomBaseCard implements LovelaceCard {
         }
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!active} style=${styleMap(iconStyle)}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -193,7 +193,7 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
         }
         return html`
             <mushroom-shape-icon style=${styleMap(iconStyle)} slot="icon">
-                <ha-state-icon .icon=${icon}></ha-state-icon>
+                <ha-state-icon .hass=${this.hass} .icon=${icon}></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -152,7 +152,12 @@ export class UpdateCard extends MushroomBaseCard implements LovelaceCard {
                 })}
                 style=${styleMap(style)}
             >
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon>
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon>
             </mushroom-shape-icon>
         `;
     }

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -141,7 +141,12 @@ export class VacuumCard extends MushroomBaseCard implements LovelaceCard {
                 style=${styleMap({})}
                 .disabled=${!isActive(stateObj)}
             >
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon
             ></mushroom-shape-icon>
         `;
     }

--- a/src/utils/base-card.ts
+++ b/src/utils/base-card.ts
@@ -64,7 +64,12 @@ export class MushroomBaseCard extends MushroomBaseElement {
         const active = isActive(stateObj);
         return html`
             <mushroom-shape-icon slot="icon" .disabled=${!active}>
-                <ha-state-icon .state=${stateObj} .icon=${icon}></ha-state-icon
+                <ha-state-icon
+                    .hass=${this.hass}
+                    .stateObj=${stateObj}
+                    .state=${stateObj}
+                    .icon=${icon}
+                ></ha-state-icon
             ></mushroom-shape-icon>
         `;
     }


### PR DESCRIPTION
## Description

Icon logic in HA front-end has changed in `2024.2`. This PR add support for that while keep backward compatibility.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
