### PR TITLE
Use tile style as default style for mushroom card

### DIFF
--- a/src/shared/state-info.ts
+++ b/src/shared/state-info.ts
@@ -35,7 +35,8 @@ export class StateItem extends LitElement {
                 font-weight: var(--card-primary-font-weight);
                 font-size: var(--card-primary-font-size);
                 line-height: var(--card-primary-line-height);
-                color: var(--primary-text-color);
+                color: var(--card-primary-color);
+                letter-spacing: var(--card-primary-letter-spacing);
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;
@@ -44,7 +45,8 @@ export class StateItem extends LitElement {
                 font-weight: var(--card-secondary-font-weight);
                 font-size: var(--card-secondary-font-size);
                 line-height: var(--card-secondary-line-height);
-                color: var(--secondary-text-color);
+                color: var(--card-secondary-color);
+                letter-spacing: var(--card-secondary-letter-spacing);
                 text-overflow: ellipsis;
                 overflow: hidden;
                 white-space: nowrap;

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -58,8 +58,8 @@ function capitalizeFirstLetter(string) {
 export const defaultColorCss = css`
     --default-red: 244, 67, 54;
     --default-pink: 233, 30, 99;
-    --default-purple: 156, 39, 176;
-    --default-deep-purple: 103, 58, 183;
+    --default-purple: 106, 107, 201;
+    --default-deep-purple: 111, 66, 193;
     --default-indigo: 63, 81, 181;
     --default-blue: 33, 150, 243;
     --default-light-blue: 3, 169, 244;
@@ -71,9 +71,11 @@ export const defaultColorCss = css`
     --default-yellow: 255, 235, 59;
     --default-amber: 255, 193, 7;
     --default-orange: 255, 152, 0;
-    --default-deep-orange: 255, 87, 34;
+    --default-deep-orange: 255, 111, 0;
     --default-brown: 121, 85, 72;
+    --default-light-grey: 189, 189, 189;
     --default-grey: 158, 158, 158;
+    --default-dark-grey: 96, 96, 96;
     --default-blue-grey: 96, 125, 139;
     --default-black: 0, 0, 0;
     --default-white: 255, 255, 255;

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -16,10 +16,14 @@ export const themeVariables = css`
     /* Card */
     --card-primary-font-size: var(--mush-card-primary-font-size, 14px);
     --card-secondary-font-size: var(--mush-card-secondary-font-size, 12px);
-    --card-primary-font-weight: var(--mush-card-primary-font-weight, bold);
-    --card-secondary-font-weight: var(--mush-card-secondary-font-weight, bolder);
-    --card-primary-line-height: var(--mush-card-primary-line-height, 1.5);
-    --card-secondary-line-height: var(--mush-card-secondary-line-height, 1.5);
+    --card-primary-font-weight: var(--mush-card-primary-font-weight, 500);
+    --card-secondary-font-weight: var(--mush-card-secondary-font-weight, 400);
+    --card-primary-line-height: var(--mush-card-primary-line-height, 20px);
+    --card-secondary-line-height: var(--mush-card-secondary-line-height, 16px);
+    --card-primary-color: var(--mush-card-primary-color, var(--primary-text-color));
+    --card-secondary-color: var(--mush-card-secondary-color, var(--primary-text-color));
+    --card-primary-letter-spacing: var(--mush-card-secondary-color, 0.1px);
+    --card-secondary-letter-spacing: var(--mush-card-secondary-color, 0.4px);
 
     /* Chips */
     --chip-spacing: var(--mush-chip-spacing, 8px);
@@ -63,8 +67,8 @@ export const themeVariables = css`
 
     /* Icon */
     --icon-border-radius: var(--mush-icon-border-radius, 50%);
-    --icon-size: var(--mush-icon-size, 42px);
-    --icon-symbol-size: var(--mush-icon-symbol-size, 0.5em);
+    --icon-size: var(--mush-icon-size, 40px);
+    --icon-symbol-size: var(--mush-icon-symbol-size, 0.6em);
 `;
 
 export const themeColorCss = css`


### PR DESCRIPTION
## Description

Use same font style as tile card
Use same color code as tile card
Use same icon size as tile card

All these variables are still editable using themes.

## Related Issue

Fixes part of issue : https://github.com/piitaya/lovelace-mushroom/issues/1259

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
