### PR TITLE
Allow use of home-assistant icons in template card secondary.

### DIFF
--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -153,24 +153,21 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
             return undefined;
         }
 
-        // Get value as a string to enable string operations
-        const textAsString = `${text}`;
-
         // Convert :mdi:abc: format strings to HA icons.
-        const parsedString = textAsString.replace(
+        const parsedText = text.replace(
             /:([a-z]{3}\:[a-z0-9\-]+):/g,
             '<ha-icon icon="$1"></ha-icon>'
         );
 
         // If initially recorded length & current length match then we have not
         // parsed any icons
-        if (parsedString.length === textAsString.length) {
-            return html`${parsedString}`;
+        if (parsedText.length === text.length) {
+            return html`${parsedText}`;
         }
 
         // Otherwise, some icons must have been found. Convert to fragment to avoid icon
         // markup being escaped
-        const fragment = document.createRange().createContextualFragment(parsedString);
+        const fragment = document.createRange().createContextualFragment(parsedText);
         // Return content
         return html`${fragment}`;
     }

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -147,6 +147,34 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
             : this._config?.[key];
     }
 
+    protected parseIcons(text: string | undefined): TemplateResult | undefined {
+        // Skip logic if no secondary is defined
+        if (text === undefined) {
+            return undefined;
+        }
+
+        // Get value as a string to enable string operations
+        const textAsString = `${text}`;
+
+        // Convert :mdi:abc: format strings to HA icons.
+        const parsedString = textAsString.replace(
+            /:([a-z]{3}\:[a-z0-9\-]+):/g,
+            '<ha-icon icon="$1"></ha-icon>'
+        );
+
+        // If initially recorded length & current length match then we have not
+        // parsed any icons
+        if (parsedString.length === textAsString.length) {
+            return html`${parsedString}`;
+        }
+
+        // Otherwise, some icons must have been found. Convert to fragment to avoid icon
+        // markup being escaped
+        const fragment = document.createRange().createContextualFragment(parsedString);
+        // Return content
+        return html`${fragment}`;
+    }
+
     protected render() {
         if (!this._config || !this.hass) {
             return nothing;
@@ -199,7 +227,7 @@ export class TemplateCard extends MushroomBaseElement implements LovelaceCard {
                         <mushroom-state-info
                             slot="info"
                             .primary=${primary}
-                            .secondary=${secondary}
+                            .secondary=${this.parseIcons(secondary)}
                             .multiline_secondary=${multiline_secondary}
                         ></mushroom-state-info>
                     </mushroom-state-item>

--- a/src/shared/state-info.ts
+++ b/src/shared/state-info.ts
@@ -9,16 +9,6 @@ export class StateItem extends LitElement {
 
     @property({ type: Boolean }) public multiline_secondary?: boolean = false;
 
-    protected parseIcons(text: string | TemplateResult): TemplateResult {
-        // Get value as a string, then convert {mdi:abc} format strings to HA icons.
-        const textAsString = `${text}`.replace(
-            /{([a-z0-9\:\-]+)}/g,
-            '<ha-icon icon="$1"></ha-icon>'
-        );
-        const fragment = document.createRange().createContextualFragment(textAsString);
-        return html`${fragment}`;
-    }
-
     protected render(): TemplateResult {
         return html`
             <div class="container">
@@ -26,7 +16,7 @@ export class StateItem extends LitElement {
                 ${this.secondary
                     ? html`<span
                           class="secondary${this.multiline_secondary ? ` multiline_secondary` : ``}"
-                          >${this.parseIcons(this.secondary)}</span
+                          >${this.secondary}</span
                       >`
                     : nothing}
             </div>
@@ -40,6 +30,7 @@ export class StateItem extends LitElement {
                 flex: 1;
                 display: flex;
                 flex-direction: column;
+                --mdc-icon-size: 16px;
             }
             .primary {
                 font-weight: var(--card-primary-font-weight);

--- a/src/shared/state-info.ts
+++ b/src/shared/state-info.ts
@@ -9,6 +9,16 @@ export class StateItem extends LitElement {
 
     @property({ type: Boolean }) public multiline_secondary?: boolean = false;
 
+    protected parseIcons(text: string | TemplateResult): TemplateResult {
+        // Get value as a string, then convert {mdi:abc} format strings to HA icons.
+        const textAsString = `${text}`.replace(
+            /{([a-z0-9\:\-]+)}/g,
+            '<ha-icon icon="$1"></ha-icon>'
+        );
+        const fragment = document.createRange().createContextualFragment(textAsString);
+        return html`${fragment}`;
+    }
+
     protected render(): TemplateResult {
         return html`
             <div class="container">
@@ -16,7 +26,7 @@ export class StateItem extends LitElement {
                 ${this.secondary
                     ? html`<span
                           class="secondary${this.multiline_secondary ? ` multiline_secondary` : ``}"
-                          >${this.secondary}</span
+                          >${this.parseIcons(this.secondary)}</span
                       >`
                     : nothing}
             </div>


### PR DESCRIPTION
## Description

This PR allows mushroom card's to use home-assistant icons in their secondary state area by defining these as `:mdi:home-assistant:` within the templates.

This allows template cards for example to be setup to show an icons for any device that is currently turned on, e.g.
![image](https://github.com/piitaya/lovelace-mushroom/assets/887397/cead8453-83d4-4126-a858-a6bf2df5b594) 
![image](https://github.com/piitaya/lovelace-mushroom/assets/887397/7a6e7ef2-1423-4f18-832e-3fbe93e298da)


This can also be used to allow for inline icons, for example next to displayed temperature values such as in the link ticket.

This has been implemented via adding a `parseIcons` function to the `state-info.ts`, which uses a rejex to swap out bracketed values, e.g. `:mdi:icon-name:` for `<ha-icon icon="mdi:icon-name"></ha-icon>`. I've wrapped this in a fragment in order to render the added HTML as part of the TemplateResult. I've additionally tweaked the css to ensure the icons are an appropriate size for the context.

I've never worked with TypeScript or Lit components before, so apologies if I've set them up wrong/butchered them a bit.  Please let me know if there are cleaner ways of approaching this.

I'd be appreciative of any guidance as to whether this change would warrant a documentation update, assuming this functionality is something that is seen as desirable to have added.

Re: code style - I ran the prettier command to format my change. I wasn't able to easily locate any additional document on the code style choices, beyond attempting to be similar to what is already there.

Note:
* I've currently implemented icons as `{mdi:sofa}` as its nice and simple, although it'd be easy to swap the regex to look for `{ icon:'mdi:sofa' }` instead.
* The change will technically allow raw html rendered in the secondary (as it bypasses the escaping in order to add the icons). Given this content is edited by the owner, I don't think* this should be a problem (this is also possible via the HA markdown cards) but is probably worth flagging in case this is a concern .

## Related Issue

This PR fixes or closes issue: fixes https://github.com/piitaya/lovelace-mushroom/issues/327

## Motivation and Context

I currently use template cards for each room of my house, which then contain logic to show a Unicode icon for each device that's is turned on in the given room within the cards secondary area. Unicode is far more limited in the range of icons i can use, so I had a go at this in order to allow for much better identification of specific devices - ie. is it a lamp or main light that's on.

Other use cases include in-line use of icons next to figures displayed (power usage by a device, a temperature reading etc)


## How Has This Been Tested

I've primarily tested this on my own home assistant instances by swapping out the build JS imported by hacs. 
I've tested a variety of icons, although as far as I'm aware only the template card allows me to directly control what text (and thus icons) are output in the secondary area.

I could make the behaviour available to `content` on the chip templates or names, if that was a desirable extension to this.

Tested in
* Chrome 123.0.6312.86 (windows)
* Edge 124.0.2478.10 (windows)
* Firefox 124.0.1 (windows)

## Types of changes

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
