### PR TITLE
Fix mwc-select menu bug

### DIFF
--- a/src/shared/form/mushroom-select-menu-surface.ts
+++ b/src/shared/form/mushroom-select-menu-surface.ts
@@ -1,0 +1,74 @@
+import {MenuSurfaceBase} from '@material/mwc-menu/mwc-menu-surface-base.js';
+import {styles} from '@material/mwc-menu/mwc-menu-surface.css.js';
+import {html, css} from 'lit';
+import {customElement, query} from 'lit/decorators.js';
+import {classMap} from 'lit/directives/class-map.js';
+import {styleMap} from 'lit/directives/style-map.js';
+
+/** */
+@customElement('mushroom-select-menu-surface')
+export class MenuSurface extends MenuSurfaceBase {
+  static override styles = [
+    styles,
+    css`
+      dialog {
+        border: 0px;
+      }
+    
+      dialog::backdrop {
+        /* must still be clickable */
+        opacity: 0;
+      }
+    
+      slot {
+        /* Makes slot clickable */
+        display: block;
+      }`
+  ];
+
+  @query('dialog') dialogEl!: HTMLDialogElement | null;
+
+  override renderSurface() {
+    const classes = this.getRootClasses();
+    const styles = this.getRootStyles();
+
+    // swap out div for dialog
+    return html`
+      <dialog
+          class=${classMap(classes)}
+          style="${styleMap(styles)}"
+          @click=${this.onScrimClick}
+          @keydown=${this.onKeydown}
+          @opened=${this.registerBodyClick}
+          @closed=${this.deregisterBodyClick}>
+        ${this.renderContent()}
+      </dialog>`;
+  }
+
+  protected onScrimClick(e: Event) {
+    // This would be false if the contents of the dialog were clicked rather
+    // than the transparent scrim
+    if (e.target === this.dialogEl) {
+      this.open = false;
+    }
+  }
+
+  override onOpenChanged(isOpen: boolean, wasOpen: boolean) {
+    super.onOpenChanged(isOpen, wasOpen);
+    if (this.dialogEl) {
+      if (isOpen) {
+        // MUST use showModal over `open` because this is the only thing that
+        // will trigger the browser's super special hoisting mechanism
+        this.dialogEl.showModal();
+      } else {
+        this.dialogEl.close();
+      }
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mushroom-select-menu-surface': MenuSurface;
+  }
+}

--- a/src/shared/form/mushroom-select-menu.ts
+++ b/src/shared/form/mushroom-select-menu.ts
@@ -1,0 +1,44 @@
+import {MenuBase} from '@material/mwc-menu/mwc-menu-base.js';
+import {styles} from '@material/mwc-menu/mwc-menu.css.js';
+import {html} from 'lit';
+import {customElement} from 'lit/decorators.js';
+import {classMap} from 'lit/directives/class-map.js';
+import './mushroom-select-menu-surface.js';
+
+/** */
+@customElement('mushroom-select-menu')
+export class Menu extends MenuBase {
+  static styles = styles;
+  override renderSurface() {
+    const classes = this.getSurfaceClasses();
+    // swap out mwc-menu surface for custom implementation
+    // also force "fixed" behavior and turn off fullwidth since that won't work
+    // with dialog. Alternatively these changes to defaults can be set in
+    // mushroom-select-menu-surface.ts
+    return html`
+      <mushroom-select-menu-surface
+        ?hidden=${!this.open}
+        .anchor=${this.anchor}
+        .open=${this.open}
+        .quick=${this.quick}
+        .corner=${this.corner}
+        .x=${this.x}
+        .y=${this.y}
+        .absolute=${this.absolute}
+        fixed
+        .menuCorner=${this.menuCorner}
+        ?stayOpenOnBodyClick=${this.stayOpenOnBodyClick}
+        class=${classMap(classes)}
+        @closed=${this.onClosed}
+        @opened=${this.onOpened}
+        @keydown=${this.onKeydown}>
+      ${this.renderList()}
+    </mushroom-select-menu-surface>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'mushroom-select-menu': Menu;
+  }
+}

--- a/src/shared/form/mushroom-select.ts
+++ b/src/shared/form/mushroom-select.ts
@@ -2,7 +2,10 @@ import { SelectBase } from "@material/mwc-select/mwc-select-base";
 import { styles } from "@material/mwc-select/mwc-select.css";
 import { css, html, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import {classMap} from 'lit/directives/class-map.js';
 import { debounce, nextRender } from "../../ha";
+import './mushroom-select-menu.js'
+
 
 @customElement("mushroom-select")
 export class MushroomSelect extends SelectBase {
@@ -15,6 +18,27 @@ export class MushroomSelect extends SelectBase {
         }
 
         return html`<span class="mdc-select__icon"><slot name="icon"></slot></span>`;
+    }
+
+    override renderMenu() {
+        const classes = this.getMenuClasses();
+        // swap out mwc-menu for mushroom-select-menu. Bindings and template taken from source.
+        return html`
+          <mushroom-select-menu
+            innerRole="listbox"
+            wrapFocus
+            class=" ${classMap(classes)}"
+            activatable
+            .fullwidth=${this.fixedMenuPosition ? false : !this.naturalMenuWidth}
+            .open=${this.menuOpen}
+            .anchor=${this.anchorElement}
+            @selected=${this.onSelected}
+            @opened=${this.onOpened}
+            @closed=${this.onClosed}
+            @items-updated=${this.onItemsUpdated}
+            @keydown=${this.handleTypeahead}>
+          ${this.renderMenuContent()}
+        </mushroom-select-menu>`;
     }
 
     connectedCallback() {
@@ -47,3 +71,4 @@ declare global {
         "mushroom-select": MushroomSelect;
     }
 }
+


### PR DESCRIPTION
## Description

Implement the workaround fix from https://gist.github.com/e111077/f740bdff9ea4e62a64fae47bbdf5797e
The menus now properly render above parent cards and do not get cut off.
This does have a few caveats, as per https://github.com/material-components/material-web/issues/832#issuecomment-1213455924 :
"When the menu is open, the rest of the DOM is inert. This means that hover styles will not apply to anything outside of the dialog unlike before. When the menu is open, it will always scroll the menu."

## Related Issue

This PR fixes or closes issue: fixes #1398

## Motivation and Context

Allows embedding of the mushroom-select card within other cards.

## How Has This Been Tested

Installed via HACS to verify new select behaviour. Everything else unchanged.

## Types of changes

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
