### PR TITLE
Remove hide_icon from showcase

### DIFF
--- a/.hass_dev/views/template-view.yaml
+++ b/.hass_dev/views/template-view.yaml
@@ -75,12 +75,10 @@ cards:
           - type: custom:mushroom-template-card
             primary: Hello, {{user}}
             secondary: How are you?
-            hide_icon: true
             icon: mdi:home
             layout: "vertical"
       - type: custom:mushroom-template-card
         primary: Hello, {{user}}
         secondary: How are you?
-        hide_icon: true
         icon: mdi:home
         layout: "horizontal"


### PR DESCRIPTION
## Description
This just fixing UI editor in development `template-view.yaml`

`hide_icon` has been removed from all cards in v2.0.0.

At path: hide_icon -- Expected a value of type `never`, but received: `true`