### PR TITLE
Fix vacation icon typo in alarm control panel card

### DIFF
--- a/src/ha/data/alarm_control_panel.ts
+++ b/src/ha/data/alarm_control_panel.ts
@@ -54,7 +54,7 @@ export const ALARM_MODES: Record<AlarmMode, AlarmConfig> = {
     armed_vacation: {
         feature: AlarmControlPanelEntityFeature.ARM_VACATION,
         service: "alarm_arm_vacation",
-        icon: "mdi:air-plane",
+        icon: "mdi:airplane",
     },
     armed_custom_bypass: {
         feature: AlarmControlPanelEntityFeature.ARM_CUSTOM_BYPASS,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Fix a typo which prevented the vacation icon to be shown in the alarm control panel card.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #1441 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested changing the mushroom.js file.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
