### PR TITLE
Improve spacing between chips

### DIFF
--- a/src/cards/chips-card/chips-card.ts
+++ b/src/cards/chips-card/chips-card.ts
@@ -121,7 +121,7 @@ export class ChipsCard extends LitElement implements LovelaceCard {
                     align-items: flex-start;
                     justify-content: flex-start;
                     flex-wrap: wrap;
-                    margin-bottom: calc(-1 * var(--chip-spacing));
+                    gap: var(--chip-spacing);
                 }
                 .chip-container.align-end {
                     justify-content: flex-end;
@@ -131,16 +131,6 @@ export class ChipsCard extends LitElement implements LovelaceCard {
                 }
                 .chip-container.align-justify {
                     justify-content: space-between;
-                }
-                .chip-container * {
-                    margin-bottom: var(--chip-spacing);
-                }
-                .chip-container *:not(:last-child) {
-                    margin-right: var(--chip-spacing);
-                }
-                .chip-container[rtl] *:not(:last-child) {
-                    margin-right: initial;
-                    margin-left: var(--chip-spacing);
                 }
             `,
         ];


### PR DESCRIPTION
## Description

This patch uses the `gap` property instead of margins on the chip cards container, which fixes some alignment bugs in some cases

**Before:**
![image](https://github.com/piitaya/lovelace-mushroom/assets/6919894/9aea3dd5-c0d9-4849-b058-6c1b3c29d860)

**After:**
![image](https://github.com/piitaya/lovelace-mushroom/assets/6919894/bdf99573-3929-483f-8cda-fae91ab674c2)


## Related Issue

This PR fixes or closes issue: fixes #1459

## Motivation and Context

This solves the problem of misaligned chips in some cases.

## How Has This Been Tested

By visually checking this in my dev instance.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
