### PR TITLE
Improve default size in sections

### DIFF
--- a/src/shared/card.ts
+++ b/src/shared/card.ts
@@ -16,6 +16,10 @@ export class Card extends LitElement {
           "no-info":
             this.appearance?.primary_info === "none" &&
             this.appearance?.secondary_info === "none",
+          "no-content":
+            this.appearance?.primary_info === "none" &&
+            this.appearance?.secondary_info === "none" &&
+            this.appearance?.icon_type === "none",
         })}
       >
         <slot></slot>
@@ -57,8 +61,16 @@ export class Card extends LitElement {
       .container > ::slotted(mushroom-state-item) {
         flex: 1;
       }
-      .container.no-info > ::slotted(mushroom-state-item) {
+      .container.horizontal.no-info > ::slotted(mushroom-state-item) {
         flex: none;
+      }
+      .container.no-content > ::slotted(mushroom-state-item) {
+        display: none;
+      }
+      .container.no-content > ::slotted(.actions) {
+        --control-spacing: var(--spacing);
+        --control-height: var(--icon-size);
+        padding: var(--control-spacing) !important;
       }
     `;
   }

--- a/src/utils/base-card.ts
+++ b/src/utils/base-card.ts
@@ -85,28 +85,67 @@ export class MushroomBaseCard<
   }
 
   public getLayoutOptions(): LovelaceLayoutOptions {
+    if (!this._config) {
+      return {
+        grid_columns: 2,
+        grid_rows: 1,
+      };
+    }
+
     const options = {
       grid_columns: 2,
-      grid_rows: 1,
+      grid_rows: 0,
     };
-    if (!this._config) return options;
+
     const appearance = computeAppearance(this._config);
-    if (appearance.layout === "vertical") {
-      options.grid_rows += 1;
-    }
-    if (appearance.layout === "horizontal") {
-      options.grid_columns = 4;
-    }
+
     const collapsible_controls =
       "collapsible_controls" in this._config &&
       Boolean(this._config.collapsible_controls);
-    if (
-      appearance?.layout !== "horizontal" &&
-      this.hasControls &&
-      (!collapsible_controls || isActive(this._stateObj!))
-    ) {
-      options.grid_rows += 1;
+
+    const hasInfo =
+      appearance.primary_info !== "none" ||
+      appearance.secondary_info !== "none";
+    const hasIcon = appearance.icon_type !== "none";
+    const active = this._stateObj && isActive(this._stateObj);
+
+    const hasControls = this.hasControls && (!collapsible_controls || active);
+
+    if (appearance.layout === "vertical") {
+      if (hasIcon) {
+        options.grid_rows += 1;
+      }
+      if (hasInfo) {
+        options.grid_rows += 1;
+      }
+      if (hasControls) {
+        options.grid_rows += 1;
+      }
     }
+
+    if (appearance.layout === "horizontal") {
+      options.grid_rows = 1;
+      options.grid_columns = 4;
+    }
+
+    if (appearance.layout === "default") {
+      if (hasInfo || hasIcon) {
+        options.grid_rows += 1;
+      }
+      if (hasControls) {
+        options.grid_rows += 1;
+      }
+    }
+
+    // If icon only, set 1x1 for size
+    if (!hasControls && !hasInfo) {
+      options.grid_columns = 1;
+      options.grid_rows = 1;
+    }
+
+    // Ensure card has at least 1 row
+    options.grid_rows = Math.max(options.grid_rows, 1);
+
     return options;
   }
 


### PR DESCRIPTION
## Description

Improve default size in sections according to config.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes https://github.com/piitaya/lovelace-mushroom/issues/1490, fixes https://github.com/piitaya/lovelace-mushroom/issues/1479

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
