### PR TITLE
Add label_id and floor_id to action.target object

### DIFF
--- a/src/ha/panels/lovelace/editor/structs/action-struct.ts
+++ b/src/ha/panels/lovelace/editor/structs/action-struct.ts
@@ -41,6 +41,7 @@ const actionConfigStructService = object({
       entity_id: optional(union([string(), array(string())])),
       device_id: optional(union([string(), array(string())])),
       area_id: optional(union([string(), array(string())])),
+      label_id: optional(union([string(), array(string())])),
     })
   ),
   confirmation: optional(actionConfigStructConfirmation),

--- a/src/ha/panels/lovelace/editor/structs/action-struct.ts
+++ b/src/ha/panels/lovelace/editor/structs/action-struct.ts
@@ -41,6 +41,7 @@ const actionConfigStructService = object({
       entity_id: optional(union([string(), array(string())])),
       device_id: optional(union([string(), array(string())])),
       area_id: optional(union([string(), array(string())])),
+      floor_id: optional(union([string(), array(string())])),
       label_id: optional(union([string(), array(string())])),
     })
   ),


### PR DESCRIPTION
## Description

Add the `label_id` to the `action.target` object

## Related Issue

This PR fixes or closes issue: fixes #1510, fixes #1427

## Motivation and Context

Allow it to add the `label_id` via the graphical editor

## How Has This Been Tested

I did `npm run build`, then pushed it to my live HA instance, reloaded the browser and it worked ;)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [X] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
