### PR TITLE
Use ui_action instead of ui-action selector

### DIFF
--- a/src/cards/title-card/title-card-editor.ts
+++ b/src/cards/title-card/title-card-editor.ts
@@ -30,11 +30,11 @@ const SCHEMA: HaFormSchema[] = [
   { name: "alignment", selector: { mush_alignment: {} } },
   {
     name: "title_tap_action",
-    selector: { "ui-action": { actions } },
+    selector: { ui_action: { actions } },
   },
   {
     name: "subtitle_tap_action",
-    selector: { "ui-action": { actions } },
+    selector: { ui_action: { actions } },
   },
 ];
 

--- a/src/shared/config/actions-config.ts
+++ b/src/shared/config/actions-config.ts
@@ -30,15 +30,15 @@ export const computeActionsFormSchema = (
   return [
     {
       name: "tap_action",
-      selector: { "ui-action": { actions } },
+      selector: { ui_action: { actions } },
     },
     {
       name: "hold_action",
-      selector: { "ui-action": { actions } },
+      selector: { ui_action: { actions } },
     },
     {
       name: "double_tap_action",
-      selector: { "ui-action": { actions } },
+      selector: { ui_action: { actions } },
     },
   ];
 };

--- a/src/utils/form/ha-selector.ts
+++ b/src/utils/form/ha-selector.ts
@@ -247,7 +247,7 @@ export interface TimeSelector {
 export type UiAction = Exclude<ActionConfig["action"], "fire-dom-event">;
 
 export interface UiActionSelector {
-  "ui-action": {
+  ui_action: {
     actions?: UiAction[];
   } | null;
 }


### PR DESCRIPTION
## Description

`ui-action` is still supported by Home Assistant as backward compatibility but it's still better to use the new name.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [x] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
