### PR TITLE
Use the same font family as the standard home assistant badges

### DIFF
--- a/src/badges/template/template-badge.ts
+++ b/src/badges/template/template-badge.ts
@@ -313,7 +313,7 @@ export class HuiEntityBadge extends LitElement implements LovelaceBadge {
         );
         --mdc-icon-size: 18px;
         text-align: center;
-        font-family: Roboto;
+        font-family: var(--paper-font-body1_-_font-family, Roboto);
       }
       .badge:focus-visible {
         --shadow-default: var(--ha-card-box-shadow, 0 0 0 0 transparent);

--- a/src/badges/template/template-badge.ts
+++ b/src/badges/template/template-badge.ts
@@ -313,7 +313,6 @@ export class HuiEntityBadge extends LitElement implements LovelaceBadge {
         );
         --mdc-icon-size: 18px;
         text-align: center;
-        font-family: var(--paper-font-body1_-_font-family, Roboto);
       }
       .badge:focus-visible {
         --shadow-default: var(--ha-card-box-shadow, 0 0 0 0 transparent);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

## Related Issue

This PR closes issue: #1612 

## Motivation and Context

The mushroom-template-badge doesn't use the same font-family as the home assistant badges. The current behaviour is described here #1612.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
- I've started a test environment following the [proper section in the README](https://github.com/piitaya/lovelace-mushroom?tab=readme-ov-file#development-server). 
- I've created a custom theme by adding `themes/my_theme/my_theme.yaml` in the `.hass_dev` folder and changing the font. The content of the file is:
```
My Theme:
  ha-card-box-shadow: 0px 2px 4px 0px rgba(0,0,0,0.16)
  ha-card-border-width: 0

  primary-font-family: "Figtree"
  secondary-font-family: "Figtree"
  paper-font-common-base_-_font-family: "var(--primary-font-family)"
  paper-font-common-code_-_font-family: "var(--primary-font-family)"
  paper-font-body1_-_font-family: "var(--primary-font-family)"
  paper-font-subhead_-_font-family: "var(--primary-font-family)"
  paper-font-headline_-_font-family: "var(--primary-font-family)"
  paper-font-caption_-_font-family: "var(--primary-font-family)"
  paper-font-title_-_font-family: "var(--primary-font-family)"
  ha-card-header-font-family: "var(--primary-font-family)"
```
I've added a `mushroom-template-badge` and a standard badge to a dashboard and checked that both the badges had the same new font.
![image](https://github.com/user-attachments/assets/1a63cb3b-6904-452c-abab-d1a65e86190f)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
