### PR TITLE
modernize thermostat auto and heat/cool icon

### DIFF
--- a/src/cards/climate-card/utils.ts
+++ b/src/cards/climate-card/utils.ts
@@ -19,7 +19,7 @@ export const CLIMATE_HVAC_ACTION_COLORS: Record<HvacAction, string> = {
 };
 
 export const CLIMATE_HVAC_MODE_ICONS: Record<HvacMode, string> = {
-  auto: "mdi:calendar-sync",
+  auto: "mdi:thermostat-auto",
   cool: "mdi:snowflake",
   dry: "mdi:water-percent",
   fan_only: "mdi:fan",

--- a/src/cards/climate-card/utils.ts
+++ b/src/cards/climate-card/utils.ts
@@ -24,7 +24,7 @@ export const CLIMATE_HVAC_MODE_ICONS: Record<HvacMode, string> = {
   dry: "mdi:water-percent",
   fan_only: "mdi:fan",
   heat: "mdi:fire",
-  heat_cool: "mdi:autorenew",
+  heat_cool: "mdi:sun-snowflake-variant",
   off: "mdi:power",
 };
 


### PR DESCRIPTION
## Description

Change thermostat auto icon from `mdi:calendar-sync` to `mdi:thermostat-auto` and heat_cool icon from `mdi:autorenew` to `mdi:sun-snowflake-variant`.

## Related Issue

This PR fixes or closes issue: fixes #1712

## Motivation and Context

The new icon is more appropriate.

## How Has This Been Tested

The icon is available since July 5 2022. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [X] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [X] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
