### PR TITLE
feat(lock): add config option to show open door button when locked

### DIFF
--- a/docs/cards/lock.md
+++ b/docs/cards/lock.md
@@ -11,19 +11,20 @@ A lock card allows you to control a lock entity.
 
 All the options are available in the lovelace editor but you can use `yaml` if you want.
 
-| Name                | Type                                                | Default     | Description                                                                         |
-| :------------------ | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
-| `entity`            | string                                              | Required    | Lock entity                                                                         |
-| `icon`              | string                                              | Optional    | Custom icon                                                                         |
-| `name`              | string                                              | Optional    | Custom name                                                                         |
-| `layout`            | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
-| `fill_container`    | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
-| `primary_info`      | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                        |
-| `secondary_info`    | `name` `state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                                                      |
-| `icon_type`         | `icon` `entity-picture` `none`                      | `icon`      | Type of icon to display                                                             |
-| `tap_action`        | action                                              | `more-info` | Home assistant action to perform on tap                                             |
-| `hold_action`       | action                                              | `more-info` | Home assistant action to perform on hold                                            |
-| `double_tap_action` | action                                              | `more-info` | Home assistant action to perform on double_tap                                      |
+| Name                           | Type                                                | Default     | Description                                                                                           |
+| :----------------------------- | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------------------------- |
+| `entity`                       | string                                              | Required    | Lock entity                                                                                           |
+| `icon`                         | string                                              | Optional    | Custom icon                                                                                           |
+| `name`                         | string                                              | Optional    | Custom name                                                                                           |
+| `layout`                       | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported                             |
+| `fill_container`               | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout                   |
+| `primary_info`                 | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                                          |
+| `secondary_info`               | `name` `state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                                                                        |
+| `icon_type`                    | `icon` `entity-picture` `none`                      | `icon`      | Type of icon to display                                                                               |
+| `tap_action`                   | action                                              | `more-info` | Home assistant action to perform on tap                                                               |
+| `hold_action`                  | action                                              | `more-info` | Home assistant action to perform on hold                                                              |
+| `double_tap_action`            | action                                              | `more-info` | Home assistant action to perform on double_tap                                                        |
+| `show_open_button_when_locked` | boolean                                             | `false`     | For compatible locks, the "Open" button is always available, whether your door is locked or unlocked. |
 
 ## Override theme variables
 

--- a/src/cards/lock-card/lock-card-config.ts
+++ b/src/cards/lock-card/lock-card-config.ts
@@ -17,7 +17,9 @@ import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-conf
 export type LockCardConfig = LovelaceCardConfig &
   EntitySharedConfig &
   AppearanceSharedConfig &
-  ActionsSharedConfig;
+  ActionsSharedConfig & {
+    show_open_button_when_locked?: boolean;
+  };
 
 export const lockCardConfigStruct = assign(
   lovelaceCardConfigStruct,
@@ -25,5 +27,8 @@ export const lockCardConfigStruct = assign(
     entitySharedConfigStruct,
     appearanceSharedConfigStruct,
     actionsSharedConfigStruct
-  )
+  ),
+  object({
+    show_open_button_when_locked: optional(boolean()),
+  })
 );

--- a/src/cards/lock-card/lock-card-editor.ts
+++ b/src/cards/lock-card/lock-card-editor.ts
@@ -12,12 +12,15 @@ import { loadHaComponents } from "../../utils/loader";
 import { LOCK_CARD_EDITOR_NAME, LOCK_ENTITY_DOMAINS } from "./const";
 import { LockCardConfig, lockCardConfigStruct } from "./lock-card-config";
 
+const LOCK_LABELS = ["show_open_button_when_locked"];
+
 const SCHEMA: HaFormSchema[] = [
   { name: "entity", selector: { entity: { domain: LOCK_ENTITY_DOMAINS } } },
   { name: "name", selector: { text: {} } },
   { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
   ...APPEARANCE_FORM_SCHEMA,
   ...computeActionsFormSchema(),
+  { name: "show_open_button_when_locked", selector: { boolean: {} } },
 ];
 
 @customElement(LOCK_CARD_EDITOR_NAME)
@@ -42,6 +45,9 @@ export class LockCardEditor
 
     if (GENERIC_LABELS.includes(schema.name)) {
       return customLocalize(`editor.card.generic.${schema.name}`);
+    }
+    if (LOCK_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.lock.${schema.name}`);
     }
     return this.hass!.localize(
       `ui.panel.lovelace.editor.card.generic.${schema.name}`

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -33,6 +33,7 @@ import {
 import "./controls/lock-buttons-control";
 import { LockCardConfig } from "./lock-card-config";
 import { isActionPending, isLocked, isUnlocked } from "./utils";
+import { FanCardConfig } from "../fan-card/fan-card-config";
 
 registerCustomCard({
   type: LOCK_CARD_NAME,
@@ -65,6 +66,18 @@ export class LockCard
 
   protected get hasControls(): boolean {
     return true;
+  }
+
+  setConfig(config: FanCardConfig): void {
+    super.setConfig({
+      tap_action: {
+        action: "toggle",
+      },
+      hold_action: {
+        action: "more-info",
+      },
+      ...config,
+    });
   }
 
   private _handleAction(ev: ActionHandlerEvent) {
@@ -114,6 +127,8 @@ export class LockCard
               .hass=${this.hass}
               .entity=${stateObj}
               .fill=${appearance.layout !== "horizontal"}
+              .show_open_button_when_locked=${this._config
+                .show_open_button_when_locked}
             >
             </mushroom-lock-buttons-control>
           </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -131,7 +131,8 @@
       "lock": {
         "lock": "Lock",
         "unlock": "Unlock",
-        "open": "Open"
+        "open": "Open",
+        "show_open_button_when_locked": "Show open button when locked?"
       },
       "humidifier": {
         "show_target_humidity_control": "Humidity control?"

--- a/src/translations/nl.json
+++ b/src/translations/nl.json
@@ -46,7 +46,8 @@
       "lock": {
         "lock": "Vergrendel",
         "open": "Open",
-        "unlock": "Ontgrendel"
+        "unlock": "Ontgrendel",
+        "show_open_button_when_locked": "Toon open-knop wanneer vergrendeld?"
       },
       "media-player": {
         "media_controls": "Mediabediening",


### PR DESCRIPTION
## Description
This PR allows showing the "Open door" button even when the lock is locked. When the lock card was initially implemented, not allowing this seemed to have been a conscious choice. But since there are a lot of locks that do support opening the door from a locked state, it makes sense to add this.

<img width="756" alt="image" src="https://github.com/user-attachments/assets/d3bbe10c-cb05-4a4b-9f22-648c0bd8a125" />
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: closes #876

## Motivation and Context
This PR implements the requested feature in #876. By making this an option, users with locks that don't support opening from the locked state can choose not to enable this.

As the `lock.open` action might leave the door ajar, some users might also find this button undesirable, as it can't be relocked without manual intervention / a (smart) door closer.
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested
Tested it on my own HA instance by uploading to the /config/www folder and loading the resource instead of the HACS resource. The attached screenshot is from my own instance. Disabling the switch will hide the "door open" button when locked, and it will still show (if supported) when the door is unlocked.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [x] 🌎 Translation (addition or update a translation)
-   [x] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [x] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
