### PR TITLE
better visualization of state in climate card

### DIFF
--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -173,14 +173,14 @@ export class ClimateCard
         "hvac_action"
       );
     }
-    if (stateObj.attributes.current_temperature !== null) {
+    if (stateObj.attributes.current_temperature != null) {
       const temperature = this.hass.formatEntityAttributeValue(
         stateObj,
         "current_temperature"
       );
       stateDisplay += ` ⸱ ${temperature}`;
     }
-    if (stateObj.attributes.current_humidity !== null) {
+    if (stateObj.attributes.current_humidity != null) {
       const humidity = this.hass.formatEntityAttributeValue(
         stateObj,
         "current_humidity"


### PR DESCRIPTION
## Description

If humidity is available for a climate device, it will be shown in state. And if hvac_action is available, it will be shown instead of hvac_mode.

## Related Issue

no issue, just an improvement

## Motivation and Context

i searched a card, where i can see my heating thermostate in a very compact view. i found mushroom cards, but i missed humidity and the hvac_action in the state (i think it is more important than the hvac_mode).

## How Has This Been Tested

In my local installation of ha.

## Types of changes

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
