### PR TITLE
Use kelvin instead of mired for light color temperature slider

### DIFF
--- a/src/cards/light-card/controls/light-color-temp-control.ts
+++ b/src/cards/light-card/controls/light-color-temp-control.ts
@@ -1,8 +1,41 @@
-import { css, CSSResultGroup, html, LitElement, TemplateResult } from "lit";
+import {
+  css,
+  html,
+  LitElement,
+  TemplateResult,
+  type CSSResultGroup,
+} from "lit";
 import { customElement, property } from "lit/decorators.js";
+import { styleMap } from "lit/directives/style-map.js";
+import memoizeOne from "memoize-one";
 import { HomeAssistant, isActive, isAvailable, LightEntity } from "../../../ha";
+import { rgb2hex } from "../../../ha/common/color/convert-color";
+import {
+  DEFAULT_MAX_KELVIN,
+  DEFAULT_MIN_KELVIN,
+  temperature2rgb,
+} from "../../../ha/common/color/convert-light-color";
 import "../../../shared/slider";
-import { getColorTemp } from "../utils";
+
+export const generateColorTemperatureGradient = (min: number, max: number) => {
+  const count = 10;
+
+  const gradient: [number, string][] = [];
+
+  const step = (max - min) / count;
+  const percentageStep = 1 / count;
+
+  for (let i = 0; i < count + 1; i++) {
+    const value = min + step * i;
+
+    const hex = rgb2hex(temperature2rgb(value));
+    gradient.push([percentageStep * i, hex]);
+  }
+
+  return gradient
+    .map(([stop, color]) => `${color} ${(stop as number) * 100}%`)
+    .join(", ");
+};
 
 @customElement("mushroom-light-color-temp-control")
 export class LightColorTempControl extends LitElement {
@@ -11,26 +44,45 @@ export class LightColorTempControl extends LitElement {
   @property({ attribute: false }) public entity!: LightEntity;
 
   onChange(e: CustomEvent<{ value: number }>): void {
+    e.stopPropagation();
     const value = e.detail.value;
 
     this.hass.callService("light", "turn_on", {
       entity_id: this.entity.entity_id,
-      color_temp: value,
+      color_temp_kelvin: value,
     });
   }
 
-  protected render(): TemplateResult {
-    const colorTemp = getColorTemp(this.entity);
+  private _generateTemperatureGradient = memoizeOne(
+    (min: number, max: number) => generateColorTemperatureGradient(min, max)
+  );
 
+  protected render(): TemplateResult {
+    const colorTemp =
+      this.entity.attributes.color_temp_kelvin != null
+        ? this.entity.attributes.color_temp_kelvin
+        : undefined;
+
+    const minKelvin =
+      this.entity.attributes.min_color_temp_kelvin ?? DEFAULT_MIN_KELVIN;
+    const maxKelvin =
+      this.entity.attributes.max_color_temp_kelvin ?? DEFAULT_MAX_KELVIN;
+
+    const gradient = this._generateTemperatureGradient(minKelvin!, maxKelvin);
+
+    console.log(gradient);
     return html`
       <mushroom-slider
         .value=${colorTemp}
         .disabled=${!isAvailable(this.entity)}
         .inactive=${!isActive(this.entity)}
-        .min=${this.entity.attributes.min_mireds ?? 0}
-        .max=${this.entity.attributes.max_mireds ?? 100}
+        .min=${minKelvin}
+        .max=${maxKelvin}
         .showIndicator=${true}
         @change=${this.onChange}
+        style=${styleMap({
+          "--temp-gradient": gradient,
+        })}
       />
     `;
   }
@@ -38,11 +90,7 @@ export class LightColorTempControl extends LitElement {
   static get styles(): CSSResultGroup {
     return css`
       mushroom-slider {
-        --gradient: -webkit-linear-gradient(
-          right,
-          rgb(255, 160, 0) 0%,
-          white 100%
-        );
+        --gradient: -webkit-linear-gradient(left, var(--temp-gradient));
       }
     `;
   }

--- a/src/ha/common/color/convert-color.ts
+++ b/src/ha/common/color/convert-color.ts
@@ -1,0 +1,162 @@
+import colors from "color-name";
+import { expandHex } from "./hex";
+
+const rgb_hex = (component: number): string => {
+  const hex = Math.round(Math.min(Math.max(component, 0), 255)).toString(16);
+  return hex.length === 1 ? `0${hex}` : hex;
+};
+
+// Conversion between HEX and RGB
+
+export const hex2rgb = (hex: string): [number, number, number] => {
+  hex = expandHex(hex);
+
+  return [
+    parseInt(hex.substring(0, 2), 16),
+    parseInt(hex.substring(2, 4), 16),
+    parseInt(hex.substring(4, 6), 16),
+  ];
+};
+
+export const rgb2hex = (rgb: [number, number, number]): string =>
+  `#${rgb_hex(rgb[0])}${rgb_hex(rgb[1])}${rgb_hex(rgb[2])}`;
+
+// Conversion between LAB, XYZ and RGB from https://github.com/gka/chroma.js
+// Copyright (c) 2011-2019, Gregor Aisch
+
+// Constants for XYZ and LAB conversion
+/* eslint-disable @typescript-eslint/naming-convention */
+const Xn = 0.95047;
+const Yn = 1;
+const Zn = 1.08883;
+/* eslint-enable @typescript-eslint/naming-convention */
+
+const t0 = 0.137931034; // 4 / 29
+const t1 = 0.206896552; // 6 / 29
+const t2 = 0.12841855; // 3 * t1 * t1
+const t3 = 0.008856452; // t1 * t1 * t1
+
+const rgb_xyz = (r: number) => {
+  r /= 255;
+  if (r <= 0.04045) {
+    return r / 12.92;
+  }
+  return ((r + 0.055) / 1.055) ** 2.4;
+};
+
+const xyz_lab = (t: number) => {
+  if (t > t3) {
+    return t ** (1 / 3);
+  }
+  return t / t2 + t0;
+};
+
+const xyz_rgb = (r: number) =>
+  255 * (r <= 0.00304 ? 12.92 * r : 1.055 * r ** (1 / 2.4) - 0.055);
+
+const lab_xyz = (t: number) => (t > t1 ? t * t * t : t2 * (t - t0));
+
+// Conversions between RGB and LAB
+
+const rgb2xyz = (rgb: [number, number, number]): [number, number, number] => {
+  let [r, g, b] = rgb;
+  r = rgb_xyz(r);
+  g = rgb_xyz(g);
+  b = rgb_xyz(b);
+  const x = xyz_lab((0.4124564 * r + 0.3575761 * g + 0.1804375 * b) / Xn);
+  const y = xyz_lab((0.2126729 * r + 0.7151522 * g + 0.072175 * b) / Yn);
+  const z = xyz_lab((0.0193339 * r + 0.119192 * g + 0.9503041 * b) / Zn);
+  return [x, y, z];
+};
+
+export const rgb2lab = (
+  rgb: [number, number, number]
+): [number, number, number] => {
+  const [x, y, z] = rgb2xyz(rgb);
+  const l = 116 * y - 16;
+  return [l < 0 ? 0 : l, 500 * (x - y), 200 * (y - z)];
+};
+
+export const lab2rgb = (
+  lab: [number, number, number]
+): [number, number, number] => {
+  const [l, a, b] = lab;
+
+  let y = (l + 16) / 116;
+  let x = isNaN(a) ? y : y + a / 500;
+  let z = isNaN(b) ? y : y - b / 200;
+
+  y = Yn * lab_xyz(y);
+  x = Xn * lab_xyz(x);
+  z = Zn * lab_xyz(z);
+
+  const r = Math.round(xyz_rgb(3.2404542 * x - 1.5371385 * y - 0.4985314 * z)); // D65 -> sRGB
+  const g = Math.round(xyz_rgb(-0.969266 * x + 1.8760108 * y + 0.041556 * z));
+  const b_ = Math.round(xyz_rgb(0.0556434 * x - 0.2040259 * y + 1.0572252 * z));
+
+  return [r, g, b_];
+};
+
+export const lab2hex = (lab: [number, number, number]): string => {
+  const rgb = lab2rgb(lab);
+  return rgb2hex(rgb);
+};
+
+export const rgb2hsv = (
+  rgb: [number, number, number]
+): [number, number, number] => {
+  const [r, g, b] = rgb;
+  const v = Math.max(r, g, b);
+  const c = v - Math.min(r, g, b);
+  const h =
+    c && (v === r ? (g - b) / c : v === g ? 2 + (b - r) / c : 4 + (r - g) / c);
+  return [60 * (h < 0 ? h + 6 : h), v && c / v, v];
+};
+
+export const hsv2rgb = (
+  hsv: [number, number, number]
+): [number, number, number] => {
+  const [h, s, v] = hsv;
+  const f = (n: number) => {
+    const k = (n + h / 60) % 6;
+    return v - v * s * Math.max(Math.min(k, 4 - k, 1), 0);
+  };
+  return [f(5), f(3), f(1)];
+};
+
+export const rgb2hs = (rgb: [number, number, number]): [number, number] =>
+  rgb2hsv(rgb).slice(0, 2) as [number, number];
+
+export const hs2rgb = (hs: [number, number]): [number, number, number] =>
+  hsv2rgb([hs[0], hs[1], 255]);
+
+export function theme2hex(themeColor: string): string {
+  if (themeColor.startsWith("#")) {
+    if (themeColor.length === 4 || themeColor.length === 5) {
+      const c = themeColor;
+      // Convert short-form hex (#abc) to 6 digit (#aabbcc). Ignore alpha channel.
+      return `#${c[1]}${c[1]}${c[2]}${c[2]}${c[3]}${c[3]}`;
+    }
+    if (themeColor.length === 9) {
+      // Ignore alpha channel.
+      return themeColor.substring(0, 7);
+    }
+    return themeColor;
+  }
+
+  const rgbFromColorName = colors[themeColor.toLowerCase()];
+  if (rgbFromColorName) {
+    return rgb2hex(rgbFromColorName);
+  }
+
+  const rgbMatch = themeColor.match(/^rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/);
+  if (rgbMatch) {
+    const [, r, g, b] = rgbMatch.map(Number);
+    return rgb2hex([r, g, b]);
+  }
+
+  // We have a named color, and there's nothing in the table,
+  // so nothing further we can do with it.
+  // Compare/border/background color will all be the same.
+  return themeColor;
+}

--- a/src/ha/common/color/convert-light-color.ts
+++ b/src/ha/common/color/convert-light-color.ts
@@ -1,0 +1,106 @@
+import { clamp } from "../number/clamp";
+
+export const DEFAULT_MIN_KELVIN = 2700;
+export const DEFAULT_MAX_KELVIN = 6500;
+
+export const temperature2rgb = (
+  temperature: number
+): [number, number, number] => {
+  const value = temperature / 100;
+  return [
+    Math.round(temperatureRed(value)),
+    Math.round(temperatureGreen(value)),
+    Math.round(temperatureBlue(value)),
+  ];
+};
+
+const temperatureRed = (temperature: number): number => {
+  if (temperature <= 66) {
+    return 255;
+  }
+  const red = 329.698727446 * (temperature - 60) ** -0.1332047592;
+  return clamp(red, 0, 255);
+};
+
+const temperatureGreen = (temperature: number): number => {
+  let green: number;
+  if (temperature <= 66) {
+    green = 99.4708025861 * Math.log(temperature) - 161.1195681661;
+  } else {
+    green = 288.1221695283 * (temperature - 60) ** -0.0755148492;
+  }
+  return clamp(green, 0, 255);
+};
+
+const temperatureBlue = (temperature: number): number => {
+  if (temperature >= 66) {
+    return 255;
+  }
+  if (temperature <= 19) {
+    return 0;
+  }
+  const blue = 138.5177312231 * Math.log(temperature - 10) - 305.0447927307;
+  return clamp(blue, 0, 255);
+};
+
+const matchMaxScale = (
+  inputColors: number[],
+  outputColors: number[]
+): number[] => {
+  const maxIn: number = Math.max(...inputColors);
+  const maxOut: number = Math.max(...outputColors);
+  let factor: number;
+  if (maxOut === 0) {
+    factor = 0.0;
+  } else {
+    factor = maxIn / maxOut;
+  }
+  return outputColors.map((value) => Math.round(value * factor));
+};
+
+export const mired2kelvin = (miredTemperature: number) =>
+  miredTemperature === 0 ? 1000000 : Math.floor(1000000 / miredTemperature);
+
+export const kelvin2mired = (kelvinTemperature: number) =>
+  kelvinTemperature === 0 ? 1000000 : Math.floor(1000000 / kelvinTemperature);
+
+export const rgbww2rgb = (
+  rgbww: [number, number, number, number, number],
+  minKelvin?: number,
+  maxKelvin?: number
+): [number, number, number] => {
+  const [r, g, b, cw, ww] = rgbww;
+  // Calculate color temperature of the white channels
+  const maxMireds: number = kelvin2mired(minKelvin ?? DEFAULT_MIN_KELVIN);
+  const minMireds: number = kelvin2mired(maxKelvin ?? DEFAULT_MAX_KELVIN);
+  const miredRange: number = maxMireds - minMireds;
+  let ctRatio: number;
+  try {
+    ctRatio = ww / (cw + ww);
+  } catch (_error) {
+    ctRatio = 0.5;
+  }
+  const colorTempMired = minMireds + ctRatio * miredRange;
+  const colorTempKelvin = colorTempMired ? mired2kelvin(colorTempMired) : 0;
+  const [wR, wG, wB] = temperature2rgb(colorTempKelvin);
+  const whiteLevel = Math.max(cw, ww) / 255;
+
+  // Add the white channels to the rgb channels.
+  const rgb = [
+    r + wR * whiteLevel,
+    g + wG * whiteLevel,
+    b + wB * whiteLevel,
+  ] as [number, number, number];
+
+  // Match the output maximum value to the input. This ensures the
+  // output doesn't overflow.
+  return matchMaxScale([r, g, b, cw, ww], rgb) as [number, number, number];
+};
+
+export const rgbw2rgb = (
+  rgbw: [number, number, number, number]
+): [number, number, number] => {
+  const [r, g, b, w] = rgbw;
+  const rgb = [r + w, g + w, b + w] as [number, number, number];
+  return matchMaxScale([r, g, b, w], rgb) as [number, number, number];
+};

--- a/src/ha/common/color/hex.ts
+++ b/src/ha/common/color/hex.ts
@@ -1,0 +1,41 @@
+import { formatHex, parse } from "culori";
+
+/**
+ * Expands a 3-digit hex color to a 6-digit hex color.
+ * @param hex - The hex color to expand.
+ * @returns The expanded hex color.
+ * @throws If the hex color is invalid.
+ */
+export const expandHex = (hex: string): string => {
+  const color = parse(hex);
+  if (!color) {
+    throw new Error(`Invalid hex color: ${hex}`);
+  }
+  const formattedColor = formatHex(color);
+  if (!formattedColor) {
+    throw new Error(`Could not format hex color: ${hex}`);
+  }
+  return formattedColor.replace("#", "");
+};
+
+/**
+ * Blends two hex colors. c1 is placed over c2, blend is c1's opacity.
+ * @param c1 - The first hex color.
+ * @param c2 - The second hex color.
+ * @param blend - The blend percentage (0-100).
+ * @returns The blended hex color.
+ */
+export const hexBlend = (c1: string, c2: string, blend = 50): string => {
+  c1 = expandHex(c1);
+  c2 = expandHex(c2);
+  let color = "";
+  for (let i = 0; i <= 5; i += 2) {
+    const h1 = parseInt(c1.substring(i, i + 2), 16);
+    const h2 = parseInt(c2.substring(i, i + 2), 16);
+    const hex = Math.floor(h2 + (h1 - h2) * (blend / 100))
+      .toString(16)
+      .padStart(2, "0");
+    color += hex;
+  }
+  return `#${color}`;
+};


### PR DESCRIPTION
## Description

Use kelvin instead of mired for light color temperature slider

## Related Issue

This PR fixes or closes issue: fixes https://github.com/piitaya/lovelace-mushroom/issues/1720

## Motivation and Context

Mired will be removed in 2026.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
