### PR TITLE
add Mushroom Input Datetime Card

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Different cards are available for differents entities :
 - 🕳 [Empty card](docs/cards/empty.md)
 - 💨 [Fan card](docs/cards/fan.md)
 - 💧 [Humidifier card](docs/cards/humidifier.md)
+- 📅 [Input datetime card](docs/cards/input-datetime.md)
 - 💡 [Light card](docs/cards/light.md)
 - 🔒 [Lock card](docs/cards/lock.md)
 - 📺 [Media card](docs/cards/media-player.md)

--- a/docs/cards/input-datetime.md
+++ b/docs/cards/input-datetime.md
@@ -1,0 +1,35 @@
+# Input datetime
+
+## Description
+
+An input datetime card displays `input_datetime` entities with the Mushroom card style.
+
+## Configuration variables
+
+All the options are available in the lovelace editor but you can use `yaml` if you want.
+
+| Name                | Type                                                | Default     | Description                                                                         |
+| :------------------ | :-------------------------------------------------- | :---------- | :---------------------------------------------------------------------------------- |
+| `entity`            | string                                              | Required    | `input_datetime` entity                                                             |
+| `icon`              | string                                              | Optional    | Custom icon                                                                         |
+| `icon_color`        | string                                              | `blue`      | Custom color for icon when entity state is active                                   |
+| `name`              | string                                              | Optional    | Custom name                                                                         |
+| `layout`            | string                                              | Optional    | Layout of the card. Vertical, horizontal and default layout are supported           |
+| `fill_container`    | boolean                                             | `false`     | Fill container or not. Useful when card is in a grid, vertical or horizontal layout |
+| `primary_info`      | `name` `state` `last-changed` `last-updated` `none` | `name`      | Info to show as primary info                                                        |
+| `secondary_info`    | `name` `state` `last-changed` `last-updated` `none` | `state`     | Info to show as secondary info                                                      |
+| `icon_type`         | `icon` `entity-picture` `none`                      | `icon`      | Type of icon to display                                                             |
+| `tap_action`        | action                                              | `more-info` | Home assistant action to perform on tap                                             |
+| `hold_action`       | action                                              | `more-info` | Home assistant action to perform on hold                                            |
+| `double_tap_action` | action                                              | `more-info` | Home assistant action to perform on double_tap                                      |
+
+## Using the card
+
+```yaml
+type: custom:mushroom-input-datetime-card
+entity: input_datetime.akku_ladegerate_lock_until
+name: Akku Ladegerät gesperrt bis
+icon: mdi:battery-lock
+primary_info: name
+secondary_info: state
+```

--- a/src/cards/input-datetime-card/const.ts
+++ b/src/cards/input-datetime-card/const.ts
@@ -1,0 +1,5 @@
+import { PREFIX_NAME } from "../../const";
+
+export const INPUT_DATETIME_CARD_NAME = `${PREFIX_NAME}-input-datetime-card`;
+export const INPUT_DATETIME_CARD_EDITOR_NAME = `${INPUT_DATETIME_CARD_NAME}-editor`;
+export const INPUT_DATETIME_ENTITY_DOMAINS = ["input_datetime"];

--- a/src/cards/input-datetime-card/input-datetime-card-config.ts
+++ b/src/cards/input-datetime-card/input-datetime-card-config.ts
@@ -1,0 +1,34 @@
+import { assign, object, optional, string } from "superstruct";
+import {
+  ActionsSharedConfig,
+  actionsSharedConfigStruct,
+} from "../../shared/config/actions-config";
+import {
+  appearanceSharedConfigStruct,
+  AppearanceSharedConfig,
+} from "../../shared/config/appearance-config";
+import {
+  entitySharedConfigStruct,
+  EntitySharedConfig,
+} from "../../shared/config/entity-config";
+import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-config";
+import { LovelaceCardConfig } from "../../ha";
+
+export type InputDatetimeCardConfig = LovelaceCardConfig &
+  EntitySharedConfig &
+  AppearanceSharedConfig &
+  ActionsSharedConfig & {
+    icon_color?: string;
+  };
+
+export const inputDatetimeCardConfigStruct = assign(
+  lovelaceCardConfigStruct,
+  assign(
+    entitySharedConfigStruct,
+    appearanceSharedConfigStruct,
+    actionsSharedConfigStruct
+  ),
+  object({
+    icon_color: optional(string()),
+  })
+);

--- a/src/cards/input-datetime-card/input-datetime-card-editor.ts
+++ b/src/cards/input-datetime-card/input-datetime-card-editor.ts
@@ -1,0 +1,95 @@
+import { html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import memoizeOne from "memoize-one";
+import { assert } from "superstruct";
+import { LocalizeFunc, LovelaceCardEditor, fireEvent } from "../../ha";
+import setupCustomlocalize from "../../localize";
+import { computeActionsFormSchema } from "../../shared/config/actions-config";
+import { computeAppearanceFormSchema } from "../../shared/config/appearance-config";
+import { MushroomBaseElement } from "../../utils/base-element";
+import { GENERIC_LABELS } from "../../utils/form/generic-fields";
+import { HaFormSchema } from "../../utils/form/ha-form";
+import { loadHaComponents } from "../../utils/loader";
+import {
+  INPUT_DATETIME_CARD_EDITOR_NAME,
+  INPUT_DATETIME_ENTITY_DOMAINS,
+} from "./const";
+import {
+  InputDatetimeCardConfig,
+  inputDatetimeCardConfigStruct,
+} from "./input-datetime-card-config";
+
+const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
+  {
+    name: "entity",
+    selector: { entity: { domain: INPUT_DATETIME_ENTITY_DOMAINS } },
+  },
+  { name: "name", selector: { text: {} } },
+  {
+    type: "grid",
+    name: "",
+    schema: [
+      {
+        name: "icon",
+        selector: { icon: {} },
+        context: { icon_entity: "entity" },
+      },
+      { name: "icon_color", selector: { ui_color: {} } },
+    ],
+  },
+  ...computeAppearanceFormSchema(localize),
+  ...computeActionsFormSchema(),
+]);
+
+@customElement(INPUT_DATETIME_CARD_EDITOR_NAME)
+export class InputDatetimeCardEditor
+  extends MushroomBaseElement
+  implements LovelaceCardEditor
+{
+  @state() private _config?: InputDatetimeCardConfig;
+
+  connectedCallback() {
+    super.connectedCallback();
+    void loadHaComponents();
+  }
+
+  public setConfig(config: InputDatetimeCardConfig): void {
+    assert(config, inputDatetimeCardConfigStruct);
+    this._config = config;
+  }
+
+  private _computeLabel = (schema: HaFormSchema) => {
+    const customLocalize = setupCustomlocalize(this.hass!);
+
+    if (GENERIC_LABELS.includes(schema.name)) {
+      return customLocalize(`editor.card.generic.${schema.name}`);
+    }
+
+    return this.hass!.localize(
+      `ui.panel.lovelace.editor.card.generic.${schema.name}`
+    );
+  };
+
+  protected render() {
+    if (!this.hass || !this._config) {
+      return nothing;
+    }
+
+    const customLocalize = setupCustomlocalize(this.hass);
+    const schema = computeSchema(customLocalize);
+
+    return html`
+      <ha-form
+        .hass=${this.hass}
+        .data=${this._config}
+        .schema=${schema}
+        .computeLabel=${this._computeLabel}
+        @value-changed=${this._valueChanged}
+      ></ha-form>
+    `;
+  }
+
+  private _valueChanged(ev: CustomEvent): void {
+    fireEvent(this, "config-changed", { config: ev.detail.value });
+  }
+}

--- a/src/cards/input-datetime-card/input-datetime-card.ts
+++ b/src/cards/input-datetime-card/input-datetime-card.ts
@@ -1,0 +1,154 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { css, CSSResultGroup, html, nothing, TemplateResult } from "lit";
+import { customElement } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { styleMap } from "lit/directives/style-map.js";
+import {
+  actionHandler,
+  ActionHandlerEvent,
+  computeRTL,
+  handleAction,
+  hasAction,
+  HomeAssistant,
+  isActive,
+  LovelaceCard,
+  LovelaceCardEditor,
+} from "../../ha";
+import "../../shared/badge-icon";
+import "../../shared/card";
+import "../../shared/shape-avatar";
+import "../../shared/shape-icon";
+import "../../shared/state-info";
+import "../../shared/state-item";
+import { computeAppearance } from "../../utils/appearance";
+import { MushroomBaseCard } from "../../utils/base-card";
+import { cardStyle } from "../../utils/card-styles";
+import { computeRgbColor } from "../../utils/colors";
+import { registerCustomCard } from "../../utils/custom-cards";
+import { computeEntityPicture } from "../../utils/info";
+import {
+  INPUT_DATETIME_CARD_EDITOR_NAME,
+  INPUT_DATETIME_CARD_NAME,
+  INPUT_DATETIME_ENTITY_DOMAINS,
+} from "./const";
+import { InputDatetimeCardConfig } from "./input-datetime-card-config";
+
+registerCustomCard({
+  type: INPUT_DATETIME_CARD_NAME,
+  name: "Mushroom Input Datetime Card",
+  description: "Card for input_datetime entities",
+});
+
+@customElement(INPUT_DATETIME_CARD_NAME)
+export class InputDatetimeCard
+  extends MushroomBaseCard<InputDatetimeCardConfig>
+  implements LovelaceCard
+{
+  public static async getConfigElement(): Promise<LovelaceCardEditor> {
+    await import("./input-datetime-card-editor");
+    return document.createElement(
+      INPUT_DATETIME_CARD_EDITOR_NAME
+    ) as LovelaceCardEditor;
+  }
+
+  public static async getStubConfig(
+    hass: HomeAssistant
+  ): Promise<InputDatetimeCardConfig> {
+    const entities = Object.keys(hass.states);
+    const inputDatetimes = entities.filter((e) =>
+      INPUT_DATETIME_ENTITY_DOMAINS.includes(e.split(".")[0])
+    );
+    return {
+      type: `custom:${INPUT_DATETIME_CARD_NAME}`,
+      entity: inputDatetimes[0],
+    };
+  }
+
+  private _handleAction(ev: ActionHandlerEvent) {
+    handleAction(this, this.hass!, this._config!, ev.detail.action!);
+  }
+
+  protected render() {
+    if (!this._config || !this.hass || !this._config.entity) {
+      return nothing;
+    }
+
+    const stateObj = this._stateObj;
+
+    if (!stateObj) {
+      return this.renderNotFound(this._config);
+    }
+
+    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const icon = this._config.icon;
+    const appearance = computeAppearance(this._config);
+
+    const picture = computeEntityPicture(stateObj, appearance.icon_type);
+
+    const rtl = computeRTL(this.hass);
+
+    return html`
+      <ha-card
+        class=${classMap({ "fill-container": appearance.fill_container })}
+      >
+        <mushroom-card .appearance=${appearance} ?rtl=${rtl}>
+          <mushroom-state-item
+            ?rtl=${rtl}
+            .appearance=${appearance}
+            @action=${this._handleAction}
+            .actionHandler=${actionHandler({
+              hasHold: hasAction(this._config.hold_action),
+              hasDoubleClick: hasAction(this._config.double_tap_action),
+            })}
+          >
+            ${picture
+              ? this.renderPicture(picture)
+              : this.renderIcon(stateObj, icon)}
+            ${this.renderBadge(stateObj)}
+            ${this.renderStateInfo(stateObj, appearance, name)}
+          </mushroom-state-item>
+        </mushroom-card>
+      </ha-card>
+    `;
+  }
+
+  renderIcon(stateObj: HassEntity, icon?: string): TemplateResult {
+    const active = isActive(stateObj);
+    const iconStyle = {};
+    const iconColor = this._config?.icon_color;
+    if (iconColor) {
+      const iconRgbColor = computeRgbColor(iconColor);
+      iconStyle["--icon-color"] = `rgb(${iconRgbColor})`;
+      iconStyle["--shape-color"] = `rgba(${iconRgbColor}, 0.2)`;
+    }
+    return html`
+      <mushroom-shape-icon
+        slot="icon"
+        .disabled=${!active}
+        style=${styleMap(iconStyle)}
+      >
+        <ha-state-icon
+          .hass=${this.hass}
+          .stateObj=${stateObj}
+          .icon=${icon}
+        ></ha-state-icon>
+      </mushroom-shape-icon>
+    `;
+  }
+
+  static get styles(): CSSResultGroup {
+    return [
+      super.styles,
+      cardStyle,
+      css`
+        mushroom-state-item {
+          cursor: pointer;
+        }
+        mushroom-shape-icon {
+          --icon-color: rgb(var(--rgb-state-entity));
+          --shape-color: rgba(var(--rgb-state-entity), 0.2);
+        }
+      `,
+    ];
+  }
+}

--- a/src/mushroom.ts
+++ b/src/mushroom.ts
@@ -8,6 +8,7 @@ import "./cards/empty-card/empty-card";
 import "./cards/entity-card/entity-card";
 import "./cards/fan-card/fan-card";
 import "./cards/humidifier-card/humidifier-card";
+import "./cards/input-datetime-card/input-datetime-card";
 import "./cards/legacy-template-card/legacy-template-card";
 import "./cards/light-card/light-card";
 import "./cards/lock-card/lock-card";


### PR DESCRIPTION
## Description
--
 
This pull request introduces a new **Mushroom Input Datetime Card** for Home Assistant `input_datetime` entities.
 
### What changed
- Added a new card implementation for `input_datetime` entities with Mushroom-style UI and action support.
- Added card constants and typed config schema for the new card.
- Added a dedicated Lovelace editor restricted to the `input_datetime` domain.
- Registered the new card in `src/mushroom.ts`.
- Added documentation for the card, including a YAML example for:
- `input_datetime.akku_ladegerate_lock_until`
- Added the card entry to the README card list.
 
## Related Issue
 
This PR fixes or closes issue: fixes #
 
## Motivation and Context
 
Home Assistant users can already model date/time states through `input_datetime`, but there was no dedicated Mushroom card for this entity type.
 
This change adds a first-class Mushroom card so `input_datetime` entities can be displayed consistently with other Mushroom cards and configured directly in Lovelace via a dedicated editor.
 
## How Has This Been Tested
 
Tested locally by running:
- `npm run build`
 
Verification performed:
- TypeScript compilation and bundling complete successfully.
- The new card and editor are included in the final build.
- Documentation files are present and linked.
 
## Types of changes
 
-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [x] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist
 
-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language.

