### PR TITLE
Use entity_name selector and formatEntityName for the name field

### DIFF
--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card-editor.ts
@@ -10,6 +10,7 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { UiAction } from "../../utils/form/ha-selector";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import {
   AlarmControlPanelCardConfig,
@@ -38,12 +39,16 @@ const states = [
 ];
 
 const computeSchema = memoizeOne(
-  (localize: LocalizeFunc, customLocalize: LocalizeFunc): HaFormSchema[] => [
+  (
+    localize: LocalizeFunc,
+    customLocalize: LocalizeFunc,
+    version: string
+  ): HaFormSchema[] => [
     {
       name: "entity",
       selector: { entity: { domain: ALARM_CONTROl_PANEL_ENTITY_DOMAINS } },
     },
-    { name: "name", selector: { text: {} } },
+    computeNameSchema(version),
     {
       name: "icon",
       selector: { icon: {} },
@@ -87,7 +92,11 @@ export class SwitchCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass!);
-    const schema = computeSchema(this.hass!.localize, customLocalize);
+    const schema = computeSchema(
+      this.hass!.localize,
+      customLocalize,
+      this.hass!.config.version
+    );
 
     return html`
       <ha-form

--- a/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
+++ b/src/cards/alarm-control-panel-card/alarm-control-panel-card.ts
@@ -35,6 +35,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import { AlarmControlPanelCardConfig } from "./alarm-control-panel-card-config";
@@ -117,7 +118,7 @@ export class AlarmControlPanelCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/chips-card/chips-card-editor.ts
+++ b/src/cards/chips-card/chips-card-editor.ts
@@ -21,6 +21,7 @@ import {
   LovelaceCardEditor,
 } from "../../ha";
 import setupCustomlocalize from "../../localize";
+import { entityNameStruct } from "../../shared/config/entity-config";
 import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-config";
 import { computeAlignmentOptions } from "../../shared/config/appearance-config";
 import { MushroomBaseElement } from "../../utils/base-element";
@@ -54,7 +55,7 @@ const backChipConfigStruct = object({
 const entityChipConfigStruct = object({
   type: literal("entity"),
   entity: optional(string()),
-  name: optional(string()),
+  name: optional(entityNameStruct),
   content_info: optional(string()),
   icon: optional(string()),
   icon_color: optional(string()),
@@ -95,7 +96,7 @@ const conditionChipConfigStruct = object({
 const lightChipConfigStruct = object({
   type: literal("light"),
   entity: optional(string()),
-  name: optional(string()),
+  name: optional(entityNameStruct),
   content_info: optional(string()),
   icon: optional(string()),
   use_light_color: optional(boolean()),

--- a/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip-editor.ts
@@ -8,6 +8,7 @@ import { computeInfoOptions } from "../../../shared/config/appearance-config";
 import { GENERIC_LABELS } from "../../../utils/form/generic-fields";
 import { HaFormSchema } from "../../../utils/form/ha-form";
 import { UiAction } from "../../../utils/form/ha-selector";
+import { computeNameSchema } from "../../../utils/form/name-schema";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { AlarmControlPanelChipConfig } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
@@ -23,26 +24,23 @@ const actions: UiAction[] = [
 ];
 
 const computeSchema = memoizeOne(
-  (customLocalize: ReturnType<typeof setupCustomlocalize>): HaFormSchema[] => [
+  (
+    customLocalize: ReturnType<typeof setupCustomlocalize>,
+    version: string
+  ): HaFormSchema[] => [
     {
       name: "entity",
       selector: { entity: { domain: ALARM_CONTROl_PANEL_ENTITY_DOMAINS } },
     },
+    computeNameSchema(version),
     {
-      type: "grid",
-      name: "",
-      schema: [
-        { name: "name", selector: { text: {} } },
-        {
-          name: "content_info",
-          selector: {
-            select: {
-              options: computeInfoOptions(customLocalize),
-              mode: "dropdown",
-            },
-          },
+      name: "content_info",
+      selector: {
+        select: {
+          options: computeInfoOptions(customLocalize),
+          mode: "dropdown",
         },
-      ],
+      },
     },
     {
       name: "icon",
@@ -83,7 +81,7 @@ export class AlarmControlPanelChipEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/chips-card/chips/alarm-control-panel-chip.ts
+++ b/src/cards/chips-card/chips/alarm-control-panel-chip.ts
@@ -12,6 +12,7 @@ import {
   HomeAssistant,
 } from "../../../ha";
 import { computeRgbColor } from "../../../utils/colors";
+import { computeEntityName } from "../../../utils/compute-entity-name";
 import { animation } from "../../../utils/entity-styles";
 import { computeInfoDisplay } from "../../../utils/info";
 import {
@@ -76,7 +77,7 @@ export class AlarmControlPanelChip extends LitElement implements LovelaceChip {
       return nothing;
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const iconColor = getStateColor(stateObj.state);
     const iconPulse = shouldPulse(stateObj.state);

--- a/src/cards/chips-card/chips/conditional-chip-editor.ts
+++ b/src/cards/chips-card/chips/conditional-chip-editor.ts
@@ -156,9 +156,7 @@ export class ConditionalChipEditor
     this._guiModeAvailable = ev.detail.guiModeAvailable;
   }
 
-  private async _handleChipPicked(
-    ev: CustomEvent
-  ): Promise<void> {
+  private async _handleChipPicked(ev: CustomEvent): Promise<void> {
     const value = ev.detail.value ?? "";
 
     if (value === "") {

--- a/src/cards/chips-card/chips/entity-chip-editor.ts
+++ b/src/cards/chips-card/chips/entity-chip-editor.ts
@@ -7,43 +7,40 @@ import { computeActionsFormSchema } from "../../../shared/config/actions-config"
 import { computeInfoOptions } from "../../../shared/config/appearance-config";
 import { GENERIC_LABELS } from "../../../utils/form/generic-fields";
 import { HaFormSchema } from "../../../utils/form/ha-form";
+import { computeNameSchema } from "../../../utils/form/name-schema";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { EntityChipConfig } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: {} } },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "name", selector: { text: {} } },
-      {
-        name: "content_info",
-        selector: {
-          select: {
-            options: computeInfoOptions(localize),
-            mode: "dropdown",
-          },
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: {} } },
+    computeNameSchema(version),
+    {
+      name: "content_info",
+      selector: {
+        select: {
+          options: computeInfoOptions(localize),
+          mode: "dropdown",
         },
       },
-    ],
-  },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "icon_color", selector: { ui_color: {} } },
-    ],
-  },
-  { name: "use_entity_picture", selector: { boolean: {} } },
-  ...computeActionsFormSchema(),
-]);
+    },
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "icon_color", selector: { ui_color: {} } },
+      ],
+    },
+    { name: "use_entity_picture", selector: { boolean: {} } },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(computeChipEditorComponentName("entity"))
 export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
@@ -72,7 +69,7 @@ export class EntityChipEditor extends LitElement implements LovelaceChipEditor {
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/chips-card/chips/entity-chip.ts
+++ b/src/cards/chips-card/chips/entity-chip.ts
@@ -21,6 +21,7 @@ import {
   isActive,
 } from "../../../ha";
 import { computeRgbColor } from "../../../utils/colors";
+import { computeEntityName } from "../../../utils/compute-entity-name";
 import { computeInfoDisplay } from "../../../utils/info";
 import {
   computeChipComponentName,
@@ -75,7 +76,7 @@ export class EntityChip extends LitElement implements LovelaceChip {
       return nothing;
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const iconColor = this._config.icon_color;
 

--- a/src/cards/chips-card/chips/light-chip-editor.ts
+++ b/src/cards/chips-card/chips/light-chip-editor.ts
@@ -7,47 +7,44 @@ import { computeActionsFormSchema } from "../../../shared/config/actions-config"
 import { computeInfoOptions } from "../../../shared/config/appearance-config";
 import { GENERIC_LABELS } from "../../../utils/form/generic-fields";
 import { HaFormSchema } from "../../../utils/form/ha-form";
+import { computeNameSchema } from "../../../utils/form/name-schema";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
 import { LightChipConfig } from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 import { LIGHT_ENTITY_DOMAINS } from "../../light-card/const";
 import { LIGHT_LABELS } from "../../light-card/light-card-editor";
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  {
-    name: "entity",
-    selector: { entity: { domain: LIGHT_ENTITY_DOMAINS } },
-  },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "name", selector: { text: {} } },
-      {
-        name: "content_info",
-        selector: {
-          select: {
-            options: computeInfoOptions(localize),
-            mode: "dropdown",
-          },
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    {
+      name: "entity",
+      selector: { entity: { domain: LIGHT_ENTITY_DOMAINS } },
+    },
+    computeNameSchema(version),
+    {
+      name: "content_info",
+      selector: {
+        select: {
+          options: computeInfoOptions(localize),
+          mode: "dropdown",
         },
       },
-    ],
-  },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "use_light_color", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(),
-]);
+    },
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "use_light_color", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(computeChipEditorComponentName("light"))
 export class LightChipEditor extends LitElement implements LovelaceChipEditor {
@@ -79,7 +76,7 @@ export class LightChipEditor extends LitElement implements LovelaceChipEditor {
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/chips-card/chips/light-chip.ts
+++ b/src/cards/chips-card/chips/light-chip.ts
@@ -12,6 +12,7 @@ import {
   isActive,
   LightEntity,
 } from "../../../ha";
+import { computeEntityName } from "../../../utils/compute-entity-name";
 import { computeInfoDisplay } from "../../../utils/info";
 import {
   computeChipComponentName,
@@ -76,7 +77,7 @@ export class LightChip extends LitElement implements LovelaceChip {
       return nothing;
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
 
     const stateDisplay = this.hass.formatEntityState(stateObj);

--- a/src/cards/chips-card/chips/quickbar-chip-editor.ts
+++ b/src/cards/chips-card/chips/quickbar-chip-editor.ts
@@ -3,7 +3,10 @@ import { customElement, property, state } from "lit/decorators.js";
 import { fireEvent, HomeAssistant } from "../../../ha";
 import { HaFormSchema } from "../../../utils/form/ha-form";
 import { computeChipEditorComponentName } from "../../../utils/lovelace/chip/chip-element";
-import { EntityChipConfig, QuickBarMode } from "../../../utils/lovelace/chip/types";
+import {
+  EntityChipConfig,
+  QuickBarMode,
+} from "../../../utils/lovelace/chip/types";
 import { LovelaceChipEditor } from "../../../utils/lovelace/types";
 import { DEFAULT_QUICKBAR_ICON, DEFAULT_QUICKBAR_MODE } from "./quickbar-chip";
 
@@ -13,14 +16,21 @@ const SCHEMA: HaFormSchema[] = [
     name: "mode",
     selector: {
       select: {
-        options: [{ value: QuickBarMode.Entity, label: "Entity" }, { value: QuickBarMode.Device, label: "Device" }, { value: QuickBarMode.Command, label: "Command" }]
-      }
-    }
+        options: [
+          { value: QuickBarMode.Entity, label: "Entity" },
+          { value: QuickBarMode.Device, label: "Device" },
+          { value: QuickBarMode.Command, label: "Command" },
+        ],
+      },
+    },
   },
 ];
 
 @customElement(computeChipEditorComponentName("quickbar"))
-export class QuickBarChipEditor extends LitElement implements LovelaceChipEditor {
+export class QuickBarChipEditor
+  extends LitElement
+  implements LovelaceChipEditor
+{
   @property({ attribute: false }) public hass?: HomeAssistant;
 
   @state() private _config?: EntityChipConfig;

--- a/src/cards/climate-card/climate-card-editor.ts
+++ b/src/cards/climate-card/climate-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import {
   ClimateCardConfig,
@@ -20,12 +21,16 @@ import { CLIMATE_CARD_EDITOR_NAME, CLIMATE_ENTITY_DOMAINS } from "./const";
 const CLIMATE_LABELS = ["hvac_modes", "show_temperature_control"] as string[];
 
 const computeSchema = memoizeOne(
-  (localize: LocalizeFunc, customLocalize: LocalizeFunc): HaFormSchema[] => [
+  (
+    localize: LocalizeFunc,
+    customLocalize: LocalizeFunc,
+    version: string
+  ): HaFormSchema[] => [
     {
       name: "entity",
       selector: { entity: { domain: CLIMATE_ENTITY_DOMAINS } },
     },
-    { name: "name", selector: { text: {} } },
+    computeNameSchema(version),
     {
       name: "icon",
       selector: { icon: {} },
@@ -96,7 +101,11 @@ export class ClimateCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(this.hass!.localize, customLocalize);
+    const schema = computeSchema(
+      this.hass!.localize,
+      customLocalize,
+      this.hass!.config.version
+    );
 
     return html`
       <ha-form

--- a/src/cards/climate-card/climate-card.ts
+++ b/src/cards/climate-card/climate-card.ts
@@ -33,6 +33,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import { ClimateCardConfig } from "./climate-card-config";
@@ -161,7 +162,7 @@ export class ClimateCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/climate-card/controls/climate-temperature-control.ts
+++ b/src/cards/climate-card/controls/climate-temperature-control.ts
@@ -39,7 +39,10 @@ export class ClimateTemperatureControl extends LitElement {
     const domain = computeStateDomain(this.entity as any);
     return (
       domain === "climate" &&
-      supportsFeature(this.entity as any, ClimateEntityFeature.TARGET_TEMPERATURE)
+      supportsFeature(
+        this.entity as any,
+        ClimateEntityFeature.TARGET_TEMPERATURE
+      )
     );
   }
 
@@ -102,7 +105,6 @@ export class ClimateTemperatureControl extends LitElement {
     const hasRange =
       this.entity.attributes.target_temp_low != null &&
       this.entity.attributes.target_temp_high != null;
-
 
     const showSingle = supportsSingle && hasSingle;
     const showRange = !showSingle && supportsRange && hasRange;

--- a/src/cards/cover-card/cover-card-editor.ts
+++ b/src/cards/cover-card/cover-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { COVER_CARD_EDITOR_NAME, COVER_ENTITY_DOMAINS } from "./const";
 import { CoverCardConfig, coverCardConfigStruct } from "./cover-card-config";
@@ -19,22 +20,28 @@ const COVER_LABELS = [
   "show_tilt_position_control",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: COVER_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
-  ...computeAppearanceFormSchema(localize),
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "show_position_control", selector: { boolean: {} } },
-      { name: "show_tilt_position_control", selector: { boolean: {} } },
-      { name: "show_buttons_control", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: COVER_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      name: "icon",
+      selector: { icon: {} },
+      context: { icon_entity: "entity" },
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        { name: "show_position_control", selector: { boolean: {} } },
+        { name: "show_tilt_position_control", selector: { boolean: {} } },
+        { name: "show_buttons_control", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(COVER_CARD_EDITOR_NAME)
 export class CoverCardEditor
@@ -73,7 +80,7 @@ export class CoverCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/cover-card/cover-card.ts
+++ b/src/cards/cover-card/cover-card.ts
@@ -31,6 +31,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import { Layout } from "../../utils/layout";
@@ -188,7 +189,7 @@ export class CoverCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/empty-card/empty-card-config.ts
+++ b/src/cards/empty-card/empty-card-config.ts
@@ -1,6 +1,6 @@
 import { lovelaceCardConfigStruct } from "../../shared/config/lovelace-card-config";
 import { LovelaceCardConfig } from "../../ha";
 
-export type EmptyCardConfig = LovelaceCardConfig
+export type EmptyCardConfig = LovelaceCardConfig;
 
 export const emptyCardConfigStruct = lovelaceCardConfigStruct;

--- a/src/cards/empty-card/empty-card-editor.ts
+++ b/src/cards/empty-card/empty-card-editor.ts
@@ -11,11 +11,14 @@ const SCHEMA: HaFormSchema[] = [
   {
     name: "description",
     type: "constant",
-  }
+  },
 ];
 
 @customElement(EMPTY_CARD_EDITOR_NAME)
-export class EntityCardEditor extends MushroomBaseElement implements LovelaceCardEditor {
+export class EntityCardEditor
+  extends MushroomBaseElement
+  implements LovelaceCardEditor
+{
   @state() private _config?: EmptyCardConfig;
 
   public setConfig(): void {

--- a/src/cards/entity-card/entity-card-editor.ts
+++ b/src/cards/entity-card/entity-card-editor.ts
@@ -9,28 +9,31 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { ENTITY_CARD_EDITOR_NAME } from "./const";
 import { EntityCardConfig, entityCardConfigStruct } from "./entity-card-config";
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: {} } },
-  { name: "name", selector: { text: {} } },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "icon_color", selector: { ui_color: {} } },
-    ],
-  },
-  ...computeAppearanceFormSchema(localize),
-  ...computeActionsFormSchema(),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: {} } },
+    computeNameSchema(version),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "icon_color", selector: { ui_color: {} } },
+      ],
+    },
+    ...computeAppearanceFormSchema(localize),
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(ENTITY_CARD_EDITOR_NAME)
 export class EntityCardEditor
@@ -66,7 +69,7 @@ export class EntityCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/entity-card/entity-card.ts
+++ b/src/cards/entity-card/entity-card.ts
@@ -24,6 +24,7 @@ import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import { ENTITY_CARD_EDITOR_NAME, ENTITY_CARD_NAME } from "./const";
@@ -72,7 +73,7 @@ export class EntityCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
 

--- a/src/cards/fan-card/controls/fan-direction-control.ts
+++ b/src/cards/fan-card/controls/fan-direction-control.ts
@@ -28,10 +28,7 @@ export class FanPercentageControl extends LitElement {
     const active = isActive(this.entity);
 
     return html`
-      <mushroom-button
-        @click=${this._onTap}
-        .disabled=${!active}
-      >
+      <mushroom-button @click=${this._onTap} .disabled=${!active}>
         <ha-icon
           .icon=${currentDirection === "reverse"
             ? "mdi:rotate-left"

--- a/src/cards/fan-card/fan-card-editor.ts
+++ b/src/cards/fan-card/fan-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { FAN_CARD_EDITOR_NAME, FAN_ENTITY_DOMAINS } from "./const";
 import { FanCardConfig, fanCardConfigStruct } from "./fan-card-config";
@@ -20,34 +21,36 @@ const FAN_LABELS = [
   "show_direction_control",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: FAN_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "icon_animation", selector: { boolean: {} } },
-    ],
-  },
-  ...computeAppearanceFormSchema(localize),
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "show_percentage_control", selector: { boolean: {} } },
-      { name: "show_oscillate_control", selector: { boolean: {} } },
-      { name: "show_direction_control", selector: { boolean: {} } },
-      { name: "collapsible_controls", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: FAN_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "icon_animation", selector: { boolean: {} } },
+      ],
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        { name: "show_percentage_control", selector: { boolean: {} } },
+        { name: "show_oscillate_control", selector: { boolean: {} } },
+        { name: "show_direction_control", selector: { boolean: {} } },
+        { name: "collapsible_controls", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(FAN_CARD_EDITOR_NAME)
 export class FanCardEditor
@@ -86,7 +89,7 @@ export class FanCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -31,6 +31,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -132,7 +133,7 @@ export class FanCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);
@@ -196,13 +197,13 @@ export class FanCard
                       `
                     : nothing}
                   ${this._config.show_direction_control
-                  ? html`
-                      <mushroom-fan-direction-control
-                        .hass=${this.hass}
-                        .entity=${stateObj}
-                      ></mushroom-fan-direction-control>
-                    `
-                  : nothing}
+                    ? html`
+                        <mushroom-fan-direction-control
+                          .hass=${this.hass}
+                          .entity=${stateObj}
+                        ></mushroom-fan-direction-control>
+                      `
+                    : nothing}
                 </div>
               `
             : nothing}

--- a/src/cards/humidifier-card/humidifier-card-editor.ts
+++ b/src/cards/humidifier-card/humidifier-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import {
   HUMIDIFIER_CARD_EDITOR_NAME,
@@ -21,24 +22,30 @@ import {
 
 const HUMIDIFIER_FIELDS = ["show_target_humidity_control"];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  {
-    name: "entity",
-    selector: { entity: { domain: HUMIDIFIER_ENTITY_DOMAINS } },
-  },
-  { name: "name", selector: { text: {} } },
-  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
-  ...computeAppearanceFormSchema(localize),
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "show_target_humidity_control", selector: { boolean: {} } },
-      { name: "collapsible_controls", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    {
+      name: "entity",
+      selector: { entity: { domain: HUMIDIFIER_ENTITY_DOMAINS } },
+    },
+    computeNameSchema(version),
+    {
+      name: "icon",
+      selector: { icon: {} },
+      context: { icon_entity: "entity" },
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        { name: "show_target_humidity_control", selector: { boolean: {} } },
+        { name: "collapsible_controls", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(HUMIDIFIER_CARD_EDITOR_NAME)
 export class HumidifierCardEditor
@@ -77,7 +84,7 @@ export class HumidifierCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/humidifier-card/humidifier-card.ts
+++ b/src/cards/humidifier-card/humidifier-card.ts
@@ -25,6 +25,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -97,7 +98,7 @@ export class HumidifierCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/light-card/light-card-editor.ts
+++ b/src/cards/light-card/light-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { LIGHT_CARD_EDITOR_NAME, LIGHT_ENTITY_DOMAINS } from "./const";
 import { LightCardConfig, lightCardConfigStruct } from "./light-card-config";
@@ -20,35 +21,37 @@ export const LIGHT_LABELS = [
   "show_color_control",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: LIGHT_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "icon_color", selector: { ui_color: {} } },
-    ],
-  },
-  ...computeAppearanceFormSchema(localize),
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "use_light_color", selector: { boolean: {} } },
-      { name: "show_brightness_control", selector: { boolean: {} } },
-      { name: "show_color_temp_control", selector: { boolean: {} } },
-      { name: "show_color_control", selector: { boolean: {} } },
-      { name: "collapsible_controls", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: LIGHT_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "icon_color", selector: { ui_color: {} } },
+      ],
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        { name: "use_light_color", selector: { boolean: {} } },
+        { name: "show_brightness_control", selector: { boolean: {} } },
+        { name: "show_color_temp_control", selector: { boolean: {} } },
+        { name: "show_color_control", selector: { boolean: {} } },
+        { name: "collapsible_controls", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(LIGHT_CARD_EDITOR_NAME)
 export class LightCardEditor
@@ -87,7 +90,7 @@ export class LightCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/light-card/light-card.ts
+++ b/src/cards/light-card/light-card.ts
@@ -32,6 +32,7 @@ import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -188,7 +189,7 @@ export class LightCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);
@@ -336,7 +337,10 @@ export class LightCard
         `;
       case "color_control":
         return html`
-          <mushroom-light-color-control .hass=${this.hass} .entity=${entity}></mushroom-light-color-control>
+          <mushroom-light-color-control
+            .hass=${this.hass}
+            .entity=${entity}
+          ></mushroom-light-color-control>
         `;
       default:
         return nothing;

--- a/src/cards/lock-card/lock-card-editor.ts
+++ b/src/cards/lock-card/lock-card-editor.ts
@@ -9,17 +9,24 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { LOCK_CARD_EDITOR_NAME, LOCK_ENTITY_DOMAINS } from "./const";
 import { LockCardConfig, lockCardConfigStruct } from "./lock-card-config";
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: LOCK_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
-  ...computeAppearanceFormSchema(localize),
-  ...computeActionsFormSchema(),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: LOCK_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      name: "icon",
+      selector: { icon: {} },
+      context: { icon_entity: "entity" },
+    },
+    ...computeAppearanceFormSchema(localize),
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(LOCK_CARD_EDITOR_NAME)
 export class LockCardEditor
@@ -55,7 +62,7 @@ export class LockCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/lock-card/lock-card.ts
+++ b/src/cards/lock-card/lock-card.ts
@@ -23,6 +23,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -82,7 +83,7 @@ export class LockCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/media-player-card/media-player-card-editor.ts
+++ b/src/cards/media-player-card/media-player-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import {
   MEDIA_PLAYER_CARD_EDITOR_NAME,
@@ -29,61 +30,67 @@ export const MEDIA_LABELS = [
   "volume_controls",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  {
-    name: "entity",
-    selector: { entity: { domain: MEDIA_PLAYER_ENTITY_DOMAINS } },
-  },
-  { name: "name", selector: { text: {} } },
-  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
-  ...computeAppearanceFormSchema(localize),
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "use_media_info", selector: { boolean: {} } },
-      { name: "show_volume_level", selector: { boolean: {} } },
-    ],
-  },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "volume_controls",
-        selector: {
-          select: {
-            options: MEDIA_PLAYER_VOLUME_CONTROLS.map((control) => ({
-              value: control,
-              label: localize(
-                `editor.card.media-player.volume_controls_list.${control}`
-              ),
-            })),
-            mode: "list",
-            multiple: true,
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    {
+      name: "entity",
+      selector: { entity: { domain: MEDIA_PLAYER_ENTITY_DOMAINS } },
+    },
+    computeNameSchema(version),
+    {
+      name: "icon",
+      selector: { icon: {} },
+      context: { icon_entity: "entity" },
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        { name: "use_media_info", selector: { boolean: {} } },
+        { name: "show_volume_level", selector: { boolean: {} } },
+      ],
+    },
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "volume_controls",
+          selector: {
+            select: {
+              options: MEDIA_PLAYER_VOLUME_CONTROLS.map((control) => ({
+                value: control,
+                label: localize(
+                  `editor.card.media-player.volume_controls_list.${control}`
+                ),
+              })),
+              mode: "list",
+              multiple: true,
+            },
           },
         },
-      },
-      {
-        name: "media_controls",
-        selector: {
-          select: {
-            options: MEDIA_LAYER_MEDIA_CONTROLS.map((control) => ({
-              value: control,
-              label: localize(
-                `editor.card.media-player.media_controls_list.${control}`
-              ),
-            })),
-            mode: "list",
-            multiple: true,
+        {
+          name: "media_controls",
+          selector: {
+            select: {
+              options: MEDIA_LAYER_MEDIA_CONTROLS.map((control) => ({
+                value: control,
+                label: localize(
+                  `editor.card.media-player.media_controls_list.${control}`
+                ),
+              })),
+              mode: "list",
+              multiple: true,
+            },
           },
         },
-      },
-      { name: "collapsible_controls", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(),
-]);
+        { name: "collapsible_controls", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(MEDIA_PLAYER_CARD_EDITOR_NAME)
 export class MediaCardEditor
@@ -122,7 +129,7 @@ export class MediaCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass!);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     return html`
       <ha-form

--- a/src/cards/media-player-card/media-player-card.ts
+++ b/src/cards/media-player-card/media-player-card.ts
@@ -169,7 +169,11 @@ export class MediaPlayerCard
     }
 
     const icon = computeMediaIcon(this._config, stateObj);
-    const nameDisplay = computeMediaNameDisplay(this._config, stateObj);
+    const nameDisplay = computeMediaNameDisplay(
+      this._config,
+      stateObj,
+      this.hass
+    );
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);
     let stateDisplay = computeMediaStateDisplay(

--- a/src/cards/media-player-card/utils.ts
+++ b/src/cards/media-player-card/utils.ts
@@ -17,6 +17,7 @@ import {
   computeMediaDescription,
   supportsFeature,
 } from "../../ha";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import {
   MediaPlayerCardConfig,
   MediaPlayerMediaControl,
@@ -36,9 +37,10 @@ export function callService(
 
 export function computeMediaNameDisplay(
   config: MediaPlayerCardConfig,
-  entity: MediaPlayerEntity
+  entity: MediaPlayerEntity,
+  hass: HomeAssistant
 ): string {
-  let name = config.name || entity.attributes.friendly_name || "";
+  let name = computeEntityName(hass, entity, config.name);
   if (
     ![UNAVAILABLE, UNKNOWN, OFF].includes(entity.state) &&
     config.use_media_info

--- a/src/cards/number-card/number-card-editor.ts
+++ b/src/cards/number-card/number-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { NUMBER_CARD_EDITOR_NAME, NUMBER_ENTITY_DOMAINS } from "./const";
 import {
@@ -19,36 +20,38 @@ import {
 
 export const NUMBER_LABELS = ["display_mode"];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: NUMBER_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "icon_color", selector: { ui_color: {} } },
-    ],
-  },
-  ...computeAppearanceFormSchema(localize),
-  {
-    name: "display_mode",
-    selector: {
-      select: {
-        options: ["default", ...DISPLAY_MODES].map((control) => ({
-          value: control,
-          label: localize(`editor.card.number.display_mode_list.${control}`),
-        })),
-        mode: "dropdown",
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: NUMBER_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "icon_color", selector: { ui_color: {} } },
+      ],
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      name: "display_mode",
+      selector: {
+        select: {
+          options: ["default", ...DISPLAY_MODES].map((control) => ({
+            value: control,
+            label: localize(`editor.card.number.display_mode_list.${control}`),
+          })),
+          mode: "dropdown",
+        },
       },
     },
-  },
-  ...computeActionsFormSchema(),
-]);
+    ...computeActionsFormSchema(),
+  ]
+);
 
 @customElement(NUMBER_CARD_EDITOR_NAME)
 export class NumberCardEditor
@@ -90,7 +93,7 @@ export class NumberCardEditor
 
     const customLocalize = setupCustomlocalize(this.hass);
 
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass.config.version);
 
     const data = { ...this._config } as any;
     if (!data.display_mode) {

--- a/src/cards/number-card/number-card.ts
+++ b/src/cards/number-card/number-card.ts
@@ -32,6 +32,7 @@ import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -115,7 +116,7 @@ export class NumberCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/person-card/person-card-editor.ts
+++ b/src/cards/person-card/person-card-editor.ts
@@ -10,6 +10,7 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { UiAction } from "../../utils/form/ha-selector";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { PERSON_CARD_EDITOR_NAME, PERSON_ENTITY_DOMAINS } from "./const";
 import { PersonCardConfig, personCardConfigStruct } from "./person-card-config";
@@ -23,13 +24,19 @@ const actions: UiAction[] = [
   "none",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: PERSON_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
-  ...computeAppearanceFormSchema(localize),
-  ...computeActionsFormSchema(actions),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: PERSON_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      name: "icon",
+      selector: { icon: {} },
+      context: { icon_entity: "entity" },
+    },
+    ...computeAppearanceFormSchema(localize),
+    ...computeActionsFormSchema(actions),
+  ]
+);
 
 @customElement(PERSON_CARD_EDITOR_NAME)
 export class SwitchCardEditor
@@ -65,7 +72,7 @@ export class SwitchCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass!);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass!.config.version);
 
     return html`
       <ha-form

--- a/src/cards/person-card/person-card.ts
+++ b/src/cards/person-card/person-card.ts
@@ -23,6 +23,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -79,7 +80,7 @@ export class PersonCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/select-card/select-card-editor.ts
+++ b/src/cards/select-card/select-card-editor.ts
@@ -10,6 +10,7 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { UiAction } from "../../utils/form/ha-selector";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { SELECT_CARD_EDITOR_NAME, SELECT_ENTITY_DOMAINS } from "./const";
 import { SelectCardConfig, selectCardConfigStruct } from "./select-card-config";
@@ -23,24 +24,26 @@ const actions: UiAction[] = [
   "none",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: SELECT_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      {
-        name: "icon",
-        selector: { icon: {} },
-        context: { icon_entity: "entity" },
-      },
-      { name: "icon_color", selector: { ui_color: {} } },
-    ],
-  },
-  ...computeAppearanceFormSchema(localize),
-  ...computeActionsFormSchema(actions),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: SELECT_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        {
+          name: "icon",
+          selector: { icon: {} },
+          context: { icon_entity: "entity" },
+        },
+        { name: "icon_color", selector: { ui_color: {} } },
+      ],
+    },
+    ...computeAppearanceFormSchema(localize),
+    ...computeActionsFormSchema(actions),
+  ]
+);
 
 @customElement(SELECT_CARD_EDITOR_NAME)
 export class SelectCardEditor
@@ -76,7 +79,7 @@ export class SelectCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass!);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass!.config.version);
 
     return html`
       <ha-form

--- a/src/cards/select-card/select-card.ts
+++ b/src/cards/select-card/select-card.ts
@@ -24,6 +24,7 @@ import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
 import { computeRgbColor } from "../../utils/colors";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -84,7 +85,7 @@ export class SelectCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
 

--- a/src/cards/update-card/update-card-editor.ts
+++ b/src/cards/update-card/update-card-editor.ts
@@ -10,6 +10,7 @@ import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
 import { UiAction } from "../../utils/form/ha-selector";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { UPDATE_CARD_EDITOR_NAME, UPDATE_ENTITY_DOMAINS } from "./const";
 import { UpdateCardConfig, updateCardConfigStruct } from "./update-card-config";
@@ -25,21 +26,27 @@ const actions: UiAction[] = [
   "none",
 ];
 
-const computeSchema = memoizeOne((localize: LocalizeFunc): HaFormSchema[] => [
-  { name: "entity", selector: { entity: { domain: UPDATE_ENTITY_DOMAINS } } },
-  { name: "name", selector: { text: {} } },
-  { name: "icon", selector: { icon: {} }, context: { icon_entity: "entity" } },
-  ...computeAppearanceFormSchema(localize),
-  {
-    type: "grid",
-    name: "",
-    schema: [
-      { name: "show_buttons_control", selector: { boolean: {} } },
-      { name: "collapsible_controls", selector: { boolean: {} } },
-    ],
-  },
-  ...computeActionsFormSchema(actions),
-]);
+const computeSchema = memoizeOne(
+  (localize: LocalizeFunc, version: string): HaFormSchema[] => [
+    { name: "entity", selector: { entity: { domain: UPDATE_ENTITY_DOMAINS } } },
+    computeNameSchema(version),
+    {
+      name: "icon",
+      selector: { icon: {} },
+      context: { icon_entity: "entity" },
+    },
+    ...computeAppearanceFormSchema(localize),
+    {
+      type: "grid",
+      name: "",
+      schema: [
+        { name: "show_buttons_control", selector: { boolean: {} } },
+        { name: "collapsible_controls", selector: { boolean: {} } },
+      ],
+    },
+    ...computeActionsFormSchema(actions),
+  ]
+);
 
 @customElement(UPDATE_CARD_EDITOR_NAME)
 export class UpdateCardEditor
@@ -78,7 +85,7 @@ export class UpdateCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass!);
-    const schema = computeSchema(customLocalize);
+    const schema = computeSchema(customLocalize, this.hass!.config.version);
 
     return html`
       <ha-form

--- a/src/cards/update-card/update-card.ts
+++ b/src/cards/update-card/update-card.ts
@@ -26,6 +26,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -91,7 +92,7 @@ export class UpdateCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/cards/vacuum-card/vacuum-card-editor.ts
+++ b/src/cards/vacuum-card/vacuum-card-editor.ts
@@ -9,6 +9,7 @@ import { computeAppearanceFormSchema } from "../../shared/config/appearance-conf
 import { MushroomBaseElement } from "../../utils/base-element";
 import { GENERIC_LABELS } from "../../utils/form/generic-fields";
 import { HaFormSchema } from "../../utils/form/ha-form";
+import { computeNameSchema } from "../../utils/form/name-schema";
 import { loadHaComponents } from "../../utils/loader";
 import { VACUUM_CARD_EDITOR_NAME, VACUUM_ENTITY_DOMAINS } from "./const";
 import {
@@ -20,9 +21,13 @@ import {
 const VACUUM_LABELS = ["commands"];
 
 const computeSchema = memoizeOne(
-  (localize: LocalizeFunc, customLocalize: LocalizeFunc): HaFormSchema[] => [
+  (
+    localize: LocalizeFunc,
+    customLocalize: LocalizeFunc,
+    version: string
+  ): HaFormSchema[] => [
     { name: "entity", selector: { entity: { domain: VACUUM_ENTITY_DOMAINS } } },
-    { name: "name", selector: { text: {} } },
+    computeNameSchema(version),
     {
       type: "grid",
       name: "",
@@ -93,7 +98,11 @@ export class VacuumCardEditor
     }
 
     const customLocalize = setupCustomlocalize(this.hass!);
-    const schema = computeSchema(this.hass!.localize, customLocalize);
+    const schema = computeSchema(
+      this.hass!.localize,
+      customLocalize,
+      this.hass!.config.version
+    );
 
     return html`
       <ha-form

--- a/src/cards/vacuum-card/vacuum-card.ts
+++ b/src/cards/vacuum-card/vacuum-card.ts
@@ -23,6 +23,7 @@ import "../../shared/state-item";
 import { computeAppearance } from "../../utils/appearance";
 import { MushroomBaseCard } from "../../utils/base-card";
 import { cardStyle } from "../../utils/card-styles";
+import { computeEntityName } from "../../utils/compute-entity-name";
 import { registerCustomCard } from "../../utils/custom-cards";
 import { computeEntityPicture } from "../../utils/info";
 import {
@@ -92,7 +93,7 @@ export class VacuumCard
       return this.renderNotFound(this._config);
     }
 
-    const name = this._config.name || stateObj.attributes.friendly_name || "";
+    const name = computeEntityName(this.hass, stateObj, this._config.name);
     const icon = this._config.icon;
     const appearance = computeAppearance(this._config);
     const picture = computeEntityPicture(stateObj, appearance.icon_type);

--- a/src/ha/common/config/version.ts
+++ b/src/ha/common/config/version.ts
@@ -1,0 +1,17 @@
+export const atLeastVersion = (
+  version: string,
+  major: number,
+  minor: number,
+  patch?: number
+): boolean => {
+  const [haMajor, haMinor, haPatch] = version.split(".", 3);
+
+  return (
+    Number(haMajor) > major ||
+    (Number(haMajor) === major &&
+      (patch === undefined
+        ? Number(haMinor) >= minor
+        : Number(haMinor) > minor ||
+          (Number(haMinor) === minor && Number(haPatch) >= patch)))
+  );
+};

--- a/src/ha/data/climate.ts
+++ b/src/ha/data/climate.ts
@@ -64,7 +64,7 @@ const hvacModeOrdering: { [key in HvacMode]: number } = {
 
 export const compareClimateHvacModes = (mode1: HvacMode, mode2: HvacMode) =>
   hvacModeOrdering[mode1] - hvacModeOrdering[mode2];
-  
+
 export const enum ClimateEntityFeature {
   TARGET_TEMPERATURE = 1,
   TARGET_TEMPERATURE_RANGE = 2,

--- a/src/ha/data/entity_name.ts
+++ b/src/ha/data/entity_name.ts
@@ -1,0 +1,19 @@
+export type EntityNameItem =
+  | {
+      type: "entity" | "device" | "area" | "floor";
+    }
+  | {
+      type: "text";
+      text: string;
+    };
+
+export interface EntityNameOptions {
+  separator?: string;
+}
+
+export interface EntityNameSelector {
+  entity_name: {
+    entity_id?: string;
+    default_name?: EntityNameItem | EntityNameItem[] | string;
+  } | null;
+}

--- a/src/ha/index.ts
+++ b/src/ha/index.ts
@@ -1,3 +1,4 @@
+export * from "./common/config/version";
 export * from "./common/const";
 export * from "./common/dom/fire_event";
 export * from "./common/dom/get_main_window";
@@ -16,6 +17,7 @@ export * from "./common/util/render-status";
 export * from "./data/climate";
 export * from "./data/cover";
 export * from "./data/entity";
+export * from "./data/entity_name";
 export * from "./data/fan";
 export * from "./data/humidifier";
 export * from "./data/light";

--- a/src/ha/types.ts
+++ b/src/ha/types.ts
@@ -9,6 +9,7 @@ import type {
   MessageBase,
 } from "home-assistant-js-websocket";
 import type { LocalizeFunc } from "./common/translations/localize";
+import type { EntityNameItem, EntityNameOptions } from "./data/entity_name";
 import type {
   FrontendLocaleData,
   TranslationCategory,
@@ -227,6 +228,11 @@ export interface HomeAssistant {
     value?: any
   ): string;
   formatEntityAttributeName(stateObj: HassEntity, attribute: string): string;
+  formatEntityName?(
+    stateObj: HassEntity,
+    name: string | EntityNameItem | EntityNameItem[] | undefined,
+    options?: EntityNameOptions
+  ): string;
 }
 
 export type Constructor<T = any> = new (...args: any[]) => T;

--- a/src/shared/config/entity-config.ts
+++ b/src/shared/config/entity-config.ts
@@ -1,9 +1,35 @@
-import { Infer, object, optional, string } from "superstruct";
+import {
+  array,
+  enums,
+  Infer,
+  literal,
+  object,
+  optional,
+  string,
+  union,
+} from "superstruct";
+import { EntityNameItem } from "../../ha";
+
+const entityNameItemStruct = union([
+  object({ type: enums(["entity", "device", "area", "floor"]) }),
+  object({ type: literal("text"), text: string() }),
+]);
+
+export const entityNameStruct = union([
+  string(),
+  entityNameItemStruct,
+  array(entityNameItemStruct),
+]);
 
 export const entitySharedConfigStruct = object({
   entity: optional(string()),
-  name: optional(string()),
+  name: optional(entityNameStruct),
   icon: optional(string()),
 });
 
-export type EntitySharedConfig = Infer<typeof entitySharedConfigStruct>;
+export type EntitySharedConfig = Omit<
+  Infer<typeof entitySharedConfigStruct>,
+  "name"
+> & {
+  name?: string | EntityNameItem | EntityNameItem[];
+};

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -136,7 +136,7 @@
         "label": "Label",
         "content": "Content",
         "entity_helper": "Used in templates and interactions",
-        "area_helper":"Used in templates"
+        "area_helper": "Used in templates"
       }
     },
     "chip": {

--- a/src/utils/compute-entity-name.ts
+++ b/src/utils/compute-entity-name.ts
@@ -1,0 +1,16 @@
+import { HassEntity } from "home-assistant-js-websocket";
+import { atLeastVersion, EntityNameItem, HomeAssistant } from "../ha";
+
+export function computeEntityName(
+  hass: HomeAssistant,
+  stateObj: HassEntity,
+  name: string | EntityNameItem | EntityNameItem[] | undefined
+): string {
+  if (atLeastVersion(hass.config.version, 2026, 4)) {
+    return hass.formatEntityName!(stateObj, name);
+  }
+  if (typeof name === "string") {
+    return name;
+  }
+  return stateObj.attributes.friendly_name || "";
+}

--- a/src/utils/form/ha-selector.ts
+++ b/src/utils/form/ha-selector.ts
@@ -1,4 +1,4 @@
-import { ActionConfig } from "../../ha";
+import { ActionConfig, EntityNameSelector } from "../../ha";
 
 export type Selector =
   | ActionSelector
@@ -22,6 +22,7 @@ export type Selector =
   | LegacyDeviceSelector
   | DurationSelector
   | EntitySelector
+  | EntityNameSelector
   | LegacyEntitySelector
   | FileSelector
   | IconSelector

--- a/src/utils/form/name-schema.ts
+++ b/src/utils/form/name-schema.ts
@@ -1,0 +1,11 @@
+import { atLeastVersion } from "../../ha";
+import { HaFormSchema } from "./ha-form";
+
+export const computeNameSchema = (version: string): HaFormSchema =>
+  atLeastVersion(version, 2026, 4)
+    ? {
+        name: "name",
+        selector: { entity_name: {} },
+        context: { entity: "entity" },
+      }
+    : { name: "name", selector: { text: {} } };

--- a/src/utils/lovelace/chip/types.ts
+++ b/src/utils/lovelace/chip/types.ts
@@ -1,5 +1,7 @@
-import { ActionConfig, HomeAssistant } from "../../../ha";
+import { ActionConfig, EntityNameItem, HomeAssistant } from "../../../ha";
 import { Info } from "../../info";
+
+type EntityName = string | EntityNameItem | EntityNameItem[];
 
 export interface LovelaceChip extends HTMLElement {
   hass?: HomeAssistant;
@@ -20,7 +22,7 @@ export type ActionChipConfig = {
 export type AlarmControlPanelChipConfig = {
   type: "alarm-control-panel";
   entity?: string;
-  name?: string;
+  name?: EntityName;
   content_info?: Info;
   icon?: string;
   icon_color?: string;
@@ -37,7 +39,7 @@ export type BackChipConfig = {
 export type EntityChipConfig = {
   type: "entity";
   entity?: string;
-  name?: string;
+  name?: EntityName;
   content_info?: Info;
   icon?: string;
   icon_color?: string;
@@ -62,7 +64,7 @@ export type QuickBarChipConfig = {
   type: "quickbar";
   icon?: string;
   mode?: QuickBarMode;
-}
+};
 
 export type WeatherChipConfig = {
   type: "weather";
@@ -96,7 +98,7 @@ export interface ConditionalChipConfig {
 export type LightChipConfig = {
   type: "light";
   entity?: string;
-  name?: string;
+  name?: EntityName;
   content_info?: Info;
   icon?: string;
   use_light_color?: boolean;


### PR DESCRIPTION
## Description

Adopts the new `entity_name` selector and `hass.formatEntityName` introduced in Home Assistant 2026.4. The `name` field on every card and chip can now be a composed name (device + entity, area, floor, custom text) instead of just a free-text string.

Affected cards: `entity`, `light`, `cover`, `fan`, `climate`, `humidifier`, `lock`, `number`, `person`, `select`, `update`, `vacuum`, `alarm-control-panel`, `media-player`.
Affected chips: `entity`, `light`, `alarm-control-panel`.

Backward compatible:
- Existing string `name` configs keep working (`formatEntityName` accepts a string).
- On Home Assistant < 2026.4, the editor falls back to the regular text selector and rendering falls back to `friendly_name` via a new `computeEntityName` helper.

In the chip editors the `name` field is moved out of its grid since the new picker is wider.

## Related Issue

This PR fixes or closes issue: fixes https://github.com/piitaya/lovelace-mushroom/issues/1810

## Motivation and Context

Home Assistant 2026.4 added a richer name picker that lets users compose names from device, entity, area, floor parts, plus custom text. Cards in HA core (tile, etc.) already use it via `hass.formatEntityName`. Mushroom now matches that behaviour, replacing the duplicated `config.name || stateObj.attributes.friendly_name || ""` pattern with a single helper, and replacing the plain text input in editors with the composable picker.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [x] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
