### PR TITLE
Fix uncaught "Subscription not found" rejection in _tryDisconnectKey

### DIFF
--- a/src/badges/template/template-badge.ts
+++ b/src/badges/template/template-badge.ts
@@ -189,13 +189,14 @@ export class MushroomTemplateBadge extends LitElement implements LovelaceBadge {
     try {
       const unsub = await unsubRenderTemplate;
       await unsub();
-      this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
         // If we get here, the connection was probably already closed. Ignore.
       } else {
         throw err;
       }
+    } finally {
+      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/badges/template/template-badge.ts
+++ b/src/badges/template/template-badge.ts
@@ -188,7 +188,7 @@ export class MushroomTemplateBadge extends LitElement implements LovelaceBadge {
 
     try {
       const unsub = await unsubRenderTemplate;
-      unsub();
+      await unsub();
       this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -274,13 +274,14 @@ export class TemplateChip extends LitElement implements LovelaceChip {
     try {
       const unsub = await unsubRenderTemplate;
       await unsub();
-      this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
         // If we get here, the connection was probably already closed. Ignore.
       } else {
         throw err;
       }
+    } finally {
+      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -273,7 +273,7 @@ export class TemplateChip extends LitElement implements LovelaceChip {
 
     try {
       const unsub = await unsubRenderTemplate;
-      unsub();
+      await unsub();
       this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {

--- a/src/cards/legacy-template-card/legacy-template-card.ts
+++ b/src/cards/legacy-template-card/legacy-template-card.ts
@@ -397,7 +397,7 @@ export class LegacyTemplateCard
 
     try {
       const unsub = await unsubRenderTemplate;
-      unsub();
+      await unsub();
       this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {

--- a/src/cards/legacy-template-card/legacy-template-card.ts
+++ b/src/cards/legacy-template-card/legacy-template-card.ts
@@ -398,13 +398,14 @@ export class LegacyTemplateCard
     try {
       const unsub = await unsubRenderTemplate;
       await unsub();
-      this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
         // If we get here, the connection was probably already closed. Ignore.
       } else {
         throw err;
       }
+    } finally {
+      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -225,7 +225,7 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
 
     try {
       const unsub = await unsubRenderTemplate;
-      unsub();
+      await unsub();
       this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -226,13 +226,14 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     try {
       const unsub = await unsubRenderTemplate;
       await unsub();
-      this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
         // If we get here, the connection was probably already closed. Ignore.
       } else {
         throw err;
       }
+    } finally {
+      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -290,13 +290,14 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
     try {
       const unsub = await unsubRenderTemplate;
       await unsub();
-      this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
         // If we get here, the connection was probably already closed. Ignore.
       } else {
         throw err;
       }
+    } finally {
+      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -289,7 +289,7 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
 
     try {
       const unsub = await unsubRenderTemplate;
-      unsub();
+      await unsub();
       this._unsubRenderTemplates.delete(key);
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {


### PR DESCRIPTION
## Description

In `_tryDisconnectKey` in the five template-based components, `unsub()` is called synchronously even though it returns `Promise<void>` (it's the `UnsubscribeFunc` returned from `home-assistant-js-websocket`'s `subscribeMessage`, which sends an `unsubscribe_subscription` message over the WS).

When the server replies `{code: 'not_found'}` — which can legitimately happen when the subscription was already removed (e.g. a fast mount→unmount before the server has confirmed the subscribe, or a WS reconnect) — the rejection appears to escape the synchronous try/catch and surfaces as `Uncaught (in promise) {code: 'not_found', message: 'Subscription not found.'}` in the DevTools console.

A proposed fix is to add a single `await` on `unsub()` in each of the five locations so the rejection falls into the existing catch handler, which already filters out `not_found` and `template_error` (the surrounding comment seems to indicate that was the intent).

Files touched (one line each):
- `src/badges/template/template-badge.ts`
- `src/cards/chips-card/chips/template-chip.ts`
- `src/cards/legacy-template-card/legacy-template-card.ts`
- `src/cards/template-card/template-card.ts`
- `src/cards/title-card/title-card.ts`

This is my first contribution to this repo — happy to adjust the approach if there's a preferred direction.

## Related Issue

This PR fixes or closes issue: fixes #1727

(May also resolve #1731, which looks like a duplicate report with a minimal repro.)

## Motivation and Context

Issue #1727 reports the console flooding with `Uncaught (in promise) Subscription not found.` messages — a problem reproducible on dashboards with template cards combined with conditionals or layouts that trigger `hui-masonry-view._createColumns` rebuilds (resize, view navigation, conditional toggling). The stack trace points into mushroom's `disconnectedCallback`.

The existing catch in `_tryDisconnectKey` already filters `not_found` and `template_error` with a comment noting "If we get here, the connection was probably already closed. Ignore." — but as written, the rejecting Promise from `unsub()` doesn't seem to reach that catch because it's not awaited.

## How Has This Been Tested

Built locally and deployed the resulting `dist/mushroom.js` to a Home Assistant instance that reliably reproduced the issue (YAML dashboard with multiple `mushroom-template-card` instances and several `conditional` cards on the same view, triggering frequent masonry rebuilds).

After deploy + hard browser reload:
- The console no longer shows `Subscription not found` during view navigation, window resize, or visual interactions.
- All `mushroom-template-card` instances continue to render correctly (icons, colors, primary/secondary text).
- No new warnings/errors in the HA backend log.

I haven't run the full repo's test suite or tested every component variant — happy to do that if useful.

## Types of changes

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
- [ ] I followed the steps if I add a new language.
