### PR TITLE
fix(fan-card): resolve WebKit/Safari bug where icon continues spinning when off

### DIFF
--- a/src/cards/fan-card/fan-card.ts
+++ b/src/cards/fan-card/fan-card.ts
@@ -255,6 +255,10 @@ export class FanCard
           --icon-color: rgb(var(--rgb-state-fan));
           --shape-color: rgba(var(--rgb-state-fan), 0.2);
         }
+        ha-state-icon {
+          animation: none;
+          transform: translateZ(0);
+        }
         .spin ha-state-icon {
           animation: var(--animation-duration) infinite linear spin;
         }


### PR DESCRIPTION
## Description

This PR resolves the issue by:
- adding an explicit animation: none fallback to the base ha-state-icon
- applying transform: translateZ(0) to force a hardware-accelerated layer redraw, ensuring Safari immediately halts the animation when the class changes

## Related Issue

This PR fixes or closes issue: fixes #1626

## Motivation and Context

WebKit/Safari browsers fail to invalidate CSS animations on child elements within a Shadow DOM when a parent class (like `.spin`) is removed. This caused the fan icon to keep spinning indefinitely after the entity was turned off.

## How Has This Been Tested

Tested on both Safari and Home Assistant Companion app on macOS 26.5 and iOS 26.5

## Types of changes

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
