### PR TITLE
Align template card design with tile card

### DIFF
--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -92,6 +92,8 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
 
   @property({ attribute: false }) public hass?: HomeAssistant;
 
+  @property({ attribute: false }) public layout?: string;
+
   @state() private _config?: TemplateCardConfig;
 
   @state() private _templateResults?: TemplateResults;
@@ -287,8 +289,9 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
   }
 
   public getGridOptions(): LovelaceGridOptions {
-    let columns: number | undefined = 6;
-    let rows: number | undefined = 0;
+    const columns = 6;
+    let min_columns = 6;
+    let rows = 0;
 
     const hasContent = Boolean(
       this._config?.icon ||
@@ -303,7 +306,7 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     const featuresCount = this._config?.features?.length || 0;
     if (featuresCount) {
       if (featurePosition === "inline") {
-        columns = 12;
+        min_columns = 12;
         rows = 1;
       } else {
         rows += featuresCount;
@@ -311,6 +314,7 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     }
 
     if (this._config?.vertical) {
+      min_columns = 3;
       if (
         this._config.primary ||
         (this._config.secondary && !this._config.icon)
@@ -319,11 +323,16 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
       }
     }
     if (this._config?.multiline_secondary) {
-      rows = undefined;
+      return {
+        columns,
+        min_columns,
+      };
     }
     return {
       columns,
       rows,
+      min_columns,
+      min_rows: rows,
     };
   }
 
@@ -412,12 +421,19 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
       "feature-only": featureOnly,
     });
 
-    const contentClasses = classMap({
-      vertical: Boolean(this._config.vertical),
-    });
-
     const { haVersion } = this.hass.connection;
     const supportTileIconHandlerOptions = atLeastHaVersion(haVersion, 2026, 2);
+    const supportFixedInfoHeight = atLeastHaVersion(haVersion, 2026, 8);
+
+    const fixedInfoHeight =
+      supportFixedInfoHeight &&
+      this.layout === "grid" &&
+      this._config.grid_options?.rows !== "auto";
+
+    const contentClasses = classMap({
+      vertical: Boolean(this._config.vertical),
+      "fixed-info-height": fixedInfoHeight,
+    });
 
     const iconActionHandlerOptions: ActionHandlerOptions = {
       disabled: !this._hasIconAction,
@@ -448,10 +464,14 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
                   ? html`
                       <ha-tile-icon
                         role=${ifDefined(
-                          this._hasIconAction ? "button" : undefined
+                          !supportTileIconHandlerOptions && this._hasIconAction
+                            ? "button"
+                            : undefined
                         )}
                         tabindex=${ifDefined(
-                          this._hasIconAction ? "0" : undefined
+                          !supportTileIconHandlerOptions && this._hasIconAction
+                            ? "0"
+                            : undefined
                         )}
                         @action=${this._handleIconAction}
                         .actionHandlerOptions=${supportTileIconHandlerOptions
@@ -562,7 +582,10 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
         left: 0;
         bottom: 0;
         right: 0;
-        border-radius: var(--ha-card-border-radius, 12px);
+        border-radius: var(
+          --ha-card-border-radius,
+          var(--ha-border-radius-lg, 12px)
+        );
         margin: calc(-1 * var(--ha-card-border-width, 1px));
         overflow: hidden;
       }
@@ -581,18 +604,31 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
         display: flex;
         flex-direction: row;
         align-items: center;
-        padding: 10px;
+        padding: 0 10px;
+        min-height: var(--row-height, 56px);
         flex: 1;
         min-width: 0;
         box-sizing: border-box;
         pointer-events: none;
         gap: 10px;
       }
+      .content:has(.multiline) {
+        padding-top: 10px;
+        padding-bottom: 10px;
+      }
 
       .vertical {
         flex-direction: column;
         text-align: center;
         justify-content: center;
+        padding: 10px var(--ha-space-2, 8px);
+      }
+      .vertical.fixed-info-height {
+        gap: 2px;
+        --ha-tile-info-gap: 2px;
+        --ha-tile-info-primary-line-height: var(--ha-space-4);
+        --ha-tile-info-primary-min-height: var(--ha-space-8);
+        --ha-tile-info-min-height: var(--ha-space-12);
       }
       .vertical ha-tile-info {
         width: 100%;
@@ -644,14 +680,15 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
       }
       hui-card-features {
         --feature-color: var(--tile-color);
-        padding: 0 12px 12px 12px;
+        padding: 0 var(--ha-space-3, 12px) var(--ha-space-3, 12px)
+          var(--ha-space-3, 12px);
         min-width: 0;
       }
       .container.horizontal hui-card-features {
-        width: calc(50% - var(--column-gap, 0px) / 2 - 12px);
+        width: calc(50% - var(--column-gap, 0px) / 2 - var(--ha-space-3, 12px));
         flex: none;
-        --feature-height: 36px;
-        padding: 0 12px;
+        --feature-height: var(--ha-space-9, 36px);
+        padding: 0 var(--ha-space-3, 12px);
         padding-inline-start: 0;
       }
       .container.feature-only {
@@ -660,10 +697,10 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
       .container.feature-only hui-card-features {
         flex: 1;
         width: 100%;
-        padding: 12px 12px 12px 12px;
+        padding: var(--ha-space-3, 12px);
       }
       .container.feature-only.horizontal hui-card-features {
-        padding: 0 12px;
+        padding: 0 var(--ha-space-3, 12px);
       }
       .container.horizontal .content:not(:has(ha-tile-info)) {
         flex: none;


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Align the template card layout with the current tile card design:

- The content row uses `min-height: var(--row-height, 56px)` with horizontal padding only, matching the tile card since HA 2026.6. Multiline secondary keeps its vertical padding.
- On HA 2026.8+, vertical cards in a grid section reserve a fixed info height so sibling tiles stay aligned (home-assistant/frontend#53370). The primary text stays on a single line like the tile card.
- `role` and `tabindex` are only set on the icon for HA older than 2026.2. Newer versions handle them inside `ha-tile-icon`, so the icon no longer creates a double tab stop.
- `getGridOptions` returns `min_columns` and `min_rows` like the tile card.
- Spacing and radius use HA design tokens with fallbacks for older versions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The tile card design evolved over the last HA releases (container refactor in 2026.2, row height sizing in 2026.6, reserved info height in 2026.8) and the template card drifted from it.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Typecheck and production build pass. Not yet compared visually against a running HA instance.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [ ] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
