### PR TITLE
Fix template resubscription after disconnect and reconnect in the same tick

### DIFF
--- a/src/badges/template/template-badge.ts
+++ b/src/badges/template/template-badge.ts
@@ -185,9 +185,12 @@ export class MushroomTemplateBadge extends LitElement implements LovelaceBadge {
     if (!unsubRenderTemplate) {
       return;
     }
+    this._unsubRenderTemplates.delete(key);
 
     try {
       const unsub = await unsubRenderTemplate;
+      // UnsubscribeFunc is typed `() => void` but resolves a promise that
+      // rejects with `not_found` if the subscription is already gone.
       await unsub();
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
@@ -195,8 +198,6 @@ export class MushroomTemplateBadge extends LitElement implements LovelaceBadge {
       } else {
         throw err;
       }
-    } finally {
-      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/chips-card/chips/template-chip.ts
+++ b/src/cards/chips-card/chips/template-chip.ts
@@ -270,9 +270,12 @@ export class TemplateChip extends LitElement implements LovelaceChip {
     if (!unsubRenderTemplate) {
       return;
     }
+    this._unsubRenderTemplates.delete(key);
 
     try {
       const unsub = await unsubRenderTemplate;
+      // UnsubscribeFunc is typed `() => void` but resolves a promise that
+      // rejects with `not_found` if the subscription is already gone.
       await unsub();
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
@@ -280,8 +283,6 @@ export class TemplateChip extends LitElement implements LovelaceChip {
       } else {
         throw err;
       }
-    } finally {
-      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/legacy-template-card/legacy-template-card.ts
+++ b/src/cards/legacy-template-card/legacy-template-card.ts
@@ -394,9 +394,12 @@ export class LegacyTemplateCard
     if (!unsubRenderTemplate) {
       return;
     }
+    this._unsubRenderTemplates.delete(key);
 
     try {
       const unsub = await unsubRenderTemplate;
+      // UnsubscribeFunc is typed `() => void` but resolves a promise that
+      // rejects with `not_found` if the subscription is already gone.
       await unsub();
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
@@ -404,8 +407,6 @@ export class LegacyTemplateCard
       } else {
         throw err;
       }
-    } finally {
-      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -224,9 +224,12 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     if (!unsubRenderTemplate) {
       return;
     }
+    this._unsubRenderTemplates.delete(key);
 
     try {
       const unsub = await unsubRenderTemplate;
+      // UnsubscribeFunc is typed `() => void` but resolves a promise that
+      // rejects with `not_found` if the subscription is already gone.
       await unsub();
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
@@ -234,8 +237,6 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
       } else {
         throw err;
       }
-    } finally {
-      this._unsubRenderTemplates.delete(key);
     }
   }
 

--- a/src/cards/title-card/title-card.ts
+++ b/src/cards/title-card/title-card.ts
@@ -160,11 +160,11 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
 
     const actionableTitle = Boolean(
       this._config.title_tap_action &&
-        this._config.title_tap_action.action !== "none"
+      this._config.title_tap_action.action !== "none"
     );
     const actionableSubtitle = Boolean(
       this._config.subtitle_tap_action &&
-        this._config.subtitle_tap_action.action !== "none"
+      this._config.subtitle_tap_action.action !== "none"
     );
 
     const rtl = computeRTL(this.hass);
@@ -286,9 +286,12 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
     if (!unsubRenderTemplate) {
       return;
     }
+    this._unsubRenderTemplates.delete(key);
 
     try {
       const unsub = await unsubRenderTemplate;
+      // UnsubscribeFunc is typed `() => void` but resolves a promise that
+      // rejects with `not_found` if the subscription is already gone.
       await unsub();
     } catch (err: any) {
       if (err.code === "not_found" || err.code === "template_error") {
@@ -296,8 +299,6 @@ export class TitleCard extends MushroomBaseElement implements LovelaceCard {
       } else {
         throw err;
       }
-    } finally {
-      this._unsubRenderTemplates.delete(key);
     }
   }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

In `_tryDisconnectKey`, the subscription map entry was deleted in a `finally` block, only after the `unsub()` WebSocket round-trip completed. During that window `_tryConnectKey` early-returns because the key is still present, so a disconnect followed by a reconnect in the same tick (masonry rebuild, view navigation) skipped resubscription and the component kept stale template results until the next `hass` update.

The key is now deleted synchronously before awaiting the unsubscription, in all five template components (template card, legacy template card, template chip, template badge, title card).

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Follow-up to #1908, which fixed the uncaught `not_found` rejection but moved the map cleanup after the unsubscription round-trip.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Typecheck and production build pass.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
