### PR TITLE
Remove min grid size from template card

### DIFF
--- a/src/cards/template-card/template-card.ts
+++ b/src/cards/template-card/template-card.ts
@@ -291,8 +291,7 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
   }
 
   public getGridOptions(): LovelaceGridOptions {
-    const columns = 6;
-    let min_columns = 6;
+    let columns = 6;
     let rows = 0;
 
     const hasContent = Boolean(
@@ -308,7 +307,7 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     const featuresCount = this._config?.features?.length || 0;
     if (featuresCount) {
       if (featurePosition === "inline") {
-        min_columns = 12;
+        columns = 12;
         rows = 1;
       } else {
         rows += featuresCount;
@@ -316,7 +315,6 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     }
 
     if (this._config?.vertical) {
-      min_columns = 3;
       if (
         this._config.primary ||
         (this._config.secondary && !this._config.icon)
@@ -327,14 +325,11 @@ export class MushroomTemplateCard extends LitElement implements LovelaceCard {
     if (this._config?.multiline_secondary) {
       return {
         columns,
-        min_columns,
       };
     }
     return {
       columns,
       rows,
-      min_columns,
-      min_rows: rows,
     };
   }
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Remove the `min_columns`/`min_rows` added to the template card grid options in #1922, restoring the 5.1.x behavior where only default `columns` and `rows` are returned.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here -->

This PR fixes or closes issue: fixes #1924

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Since 5.2.1, HA clamps the template card to a minimum of 6 columns in horizontal layout, breaking existing dashboards using `grid_options.columns` below 6.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] 🐛 Bug fix (non-breaking change which fixes an issue)
-   [ ] 🚀 New feature (non-breaking change which adds functionality)
-   [ ] 🌎 Translation (addition or update a translation)
-   [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
-   [ ] 📚 Documentation (fix or addition in the documentation)
-   [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I have updated the documentation accordingly.
-   [x] I have tested the change locally.
-   [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
