### PR TITLE
Update Brazilian Portuguese translation

### DIFF
--- a/src/translations/pt-BR.json
+++ b/src/translations/pt-BR.json
@@ -3,6 +3,14 @@
     "not_found": "Entidade não encontrada"
   },
   "editor": {
+    "badge": {
+      "template": {
+        "area_helper": "Usada em modelos",
+        "content": "Conteúdo",
+        "entity_helper": "Usada em modelos e interações",
+        "label": "Rótulo"
+      }
+    },
     "card": {
       "chips": {
         "alignment": "Alinhamento"
@@ -25,14 +33,18 @@
         "show_percentage_control": "Controle de porcentagem?"
       },
       "generic": {
+        "area": "Área",
         "collapsible_controls": "Recolher controles quando desligado",
         "color": "Cor",
         "content_info": "Conteúdo",
+        "entity": "Entidade",
         "fill_container": "Preencher espaço",
         "icon_animation": "Animar ícone quando ativo?",
         "icon_color": "Cor do ícone",
         "icon_type": "Tipo do ícone",
         "layout": "Layout",
+        "picture": "Imagem",
+        "picture_helper": "Se definida, irá substituir o ícone.",
         "primary_info": "Informação primária",
         "secondary_info": "Informação secundária",
         "use_entity_picture": "Usar imagem da entidade?"
@@ -81,17 +93,27 @@
         }
       },
       "template": {
+        "area": "Área",
+        "area_helper": "Usada em modelos e recursos",
+        "badge": "Badge",
         "badge_color": "Cor do badge",
         "badge_icon": "Ícone do badge",
+        "badge_text": "Texto do badge",
+        "badge_text_helper": "Se definido, irá substituir o ícone.",
         "content": "Conteúdo",
         "entity_extra": "Usado em modelos e ações",
-        "label": "Label",
-        "multiline_secondary": "Multilinha secundária?",
+        "entity_helper": "Usada em modelos, interações e recursos",
+        "entity_helper_legacy": "Usada em modelos e interações",
+        "label": "Rótulo",
+        "layout": "Layout",
+        "multiline_secondary": "Permitir informação secundária em várias linhas",
+        "multiline_secondary_helper": "O card pode ficar mais alto para acomodar o texto e nem sempre irá se alinhar ao sistema de grade.",
         "picture": "Imagem (irá substituir o ícone)",
         "primary": "Informação primária",
         "secondary": "Informação secundária"
       },
       "title": {
+        "alignment": "Alinhamento",
         "subtitle": "Legenda",
         "subtitle_tap_action": "Ação de toque na legenda",
         "title": "Título",
@@ -179,6 +201,21 @@
           "vertical": "Layout vertical"
         }
       }
+    },
+    "section": {
+      "badge": "Badge",
+      "content": "Conteúdo",
+      "context": "Contexto",
+      "features": "Recursos",
+      "interactions": "Interações",
+      "layout": "Layout"
     }
+  },
+  "migration": {
+    "description": "A configuração do seu card foi migrada para a nova versão. Você encontra mais informações sobre as mudanças {link}.",
+    "ok": "Ok",
+    "post": "no post do GitHub",
+    "revert": "Reverter",
+    "title": "Card atualizado"
   }
 }


### PR DESCRIPTION
## Description

Updates the Brazilian Portuguese (`pt-BR`) translation.

- Adds the 29 keys that were missing compared to `en.json`: the `editor.section` group, `editor.badge.template`, the new `editor.card.generic` and `editor.card.template` entries (area, entity, picture, badge text and the related helper texts), `editor.card.title.alignment` and the whole `migration` group.
- Updates `editor.card.template.multiline_secondary`, whose source string changed from a question to a toggle label.
- Translates `editor.card.template.label` ("Label" → "Rótulo"), which had been left in English.
- Sorts the keys alphabetically, matching the other translation files.

The legacy `entity_extra` and `template.picture` keys are kept, as in the other locales.

## Related Issue

N/A — translation update.

## Motivation and Context

Several strings introduced in recent releases had no Brazilian Portuguese translation and were falling back to English in the card editors.

## How Has This Been Tested

`npm run build` runs successfully. The file was checked against `en.json` to confirm every key is present with no leftover ones, and `prettier --check` passes.

## Types of changes

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🌎 Translation (addition or update a translation)
- [ ] ⚙️ Tech (code style improvement, performance improvement or dependencies bump)
- [ ] 📚 Documentation (fix or addition in the documentation)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have tested the change locally.
- [ ] I followed [the steps](https://github.com/piitaya/lovelace-mushroom#maintainer-steps-to-add-a-new-language) if I add a new language .
